### PR TITLE
Use ${DSDIR} variable

### DIFF
--- a/scripts/build_fedora_27.sh
+++ b/scripts/build_fedora_27.sh
@@ -22,7 +22,7 @@ mkdir -p ${DSDIR}
 # add max depth or copy over
 if [ ! -d ${DSDIR}/devsim ]; then
     (
-    cd DevSim &&
+    cd ${DSDIR} &&
     git clone https://github.com/devsim/devsim &&
     cd devsim &&
     git submodule init &&


### PR DESCRIPTION
Use ${DSDIR} variable to point to the right directory. Without it, the build breaks.