### PR TITLE
Allowing custom functions registered in python to work in extended float128 precision

### DIFF
--- a/src/commands/ModelCommands.cc
+++ b/src/commands/ModelCommands.cc
@@ -2155,6 +2155,9 @@ registerFunctionCmd(CommandHandler &data)
     return;
   }
 
+#ifdef DEVSIM_EXTENDED_PRECISION
+  MathEval<float128>::GetInstance().AddTclMath(name, procedure, static_cast<size_t>(nargs), errorString);
+#endif
   MathEval<double>::GetInstance().AddTclMath(name, procedure, static_cast<size_t>(nargs), errorString);
 
   if (!errorString.empty())


### PR DESCRIPTION
Should fix this issue: https://github.com/devsim/devsim/issues/100#issue-1555844605