### PR TITLE
Regex saved fields to optionally reduce TecPlot output file size

### DIFF
--- a/src/meshing/DevsimRestartWriter.cc
+++ b/src/meshing/DevsimRestartWriter.cc
@@ -398,7 +398,7 @@ DevsimRestartWriter::~DevsimRestartWriter()
 {
 }
 
-bool DevsimRestartWriter::WriteMesh_(const std::string &deviceName, const std::string &filename, std::string &errorString)
+bool DevsimRestartWriter::WriteMesh_(const std::string &deviceName, const std::string &filename, std::vector<std::string> &include, std::vector<std::string> &exclude, std::string &errorString)
 {
     bool ret = true;
     std::ostringstream os;
@@ -418,7 +418,7 @@ bool DevsimRestartWriter::WriteMesh_(const std::string &deviceName, const std::s
     return ret;
 }
 
-bool DevsimRestartWriter::WriteMeshes_(const std::string &filename, std::string &errorString)
+bool DevsimRestartWriter::WriteMeshes_(const std::string &filename, std::vector<std::string> &include, std::vector<std::string> &exclude, std::string &errorString)
 {
     bool ret = true;
     std::ostringstream os;

--- a/src/meshing/DevsimRestartWriter.hh
+++ b/src/meshing/DevsimRestartWriter.hh
@@ -9,12 +9,13 @@ SPDX-License-Identifier: Apache-2.0
 #define DEVSIM_RESTART_WRITER_HH
 #include "MeshWriter.hh"
 #include <string>
+#include <vector>
 /// Start out by writing the all out to one file
 class DevsimRestartWriter : public MeshWriter {
     public:
         ~DevsimRestartWriter();
     private:
-        bool WriteMeshes_(const std::string &/*filename*/, std::string &/*errorString*/);
-        bool WriteMesh_(const std::string &/*deviceName*/, const std::string &/*filename*/, std::string &/*errorString*/);
+        bool WriteMeshes_(const std::string &/*filename*/, std::vector<std::string> &/*include*/, std::vector<std::string> &/*exclude*/, std::string &/*errorString*/);
+        bool WriteMesh_(const std::string &/*deviceName*/, const std::string &/*filename*/, std::vector<std::string> &/*include*/, std::vector<std::string> &/*exclude*/, std::string &/*errorString*/);
 };
 #endif

--- a/src/meshing/DevsimWriter.cc
+++ b/src/meshing/DevsimWriter.cc
@@ -237,7 +237,7 @@ DevsimWriter::~DevsimWriter()
 {
 }
 
-bool DevsimWriter::WriteMesh_(const std::string &deviceName, const std::string &filename, std::string &errorString)
+bool DevsimWriter::WriteMesh_(const std::string &deviceName, const std::string &filename, std::vector<std::string> &include, std::vector<std::string> &exclude, std::string &errorString)
 {
     bool ret = true;
     std::ostringstream os;
@@ -257,7 +257,7 @@ bool DevsimWriter::WriteMesh_(const std::string &deviceName, const std::string &
     return ret;
 }
 
-bool DevsimWriter::WriteMeshes_(const std::string &filename, std::string &errorString)
+bool DevsimWriter::WriteMeshes_(const std::string &filename, std::vector<std::string> &include, std::vector<std::string> &exclude, std::string &errorString)
 {
     bool ret = true;
     std::ostringstream os;

--- a/src/meshing/DevsimWriter.hh
+++ b/src/meshing/DevsimWriter.hh
@@ -9,12 +9,13 @@ SPDX-License-Identifier: Apache-2.0
 #define DEVSIM_WRITER_HH
 #include "MeshWriter.hh"
 #include <string>
+#include <vector>
 /// Start out by writing the all out to one file
 class DevsimWriter : public MeshWriter {
     public:
         ~DevsimWriter();
     private:
-        bool WriteMeshes_(const std::string &/*filename*/, std::string &/*errorString*/);
-        bool WriteMesh_(const std::string &/*deviceName*/, const std::string &/*filename*/, std::string &/*errorString*/);
+        bool WriteMeshes_(const std::string &/*filename*/, std::vector<std::string> &/*include*/, std::vector<std::string> &/*exclude*/, std::string &/*errorString*/);
+        bool WriteMesh_(const std::string &/*deviceName*/, const std::string &/*filename*/, std::vector<std::string> &/*include*/, std::vector<std::string> &/*exclude*/, std::string &/*errorString*/);
 };
 #endif

--- a/src/meshing/FloodsWriter.cc
+++ b/src/meshing/FloodsWriter.cc
@@ -218,7 +218,7 @@ FloodsWriter::~FloodsWriter()
 {
 }
 
-bool FloodsWriter::WriteMesh_(const std::string &deviceName, const std::string &filename, std::string &errorString)
+bool FloodsWriter::WriteMesh_(const std::string &deviceName, const std::string &filename, std::vector<std::string> &include, std::vector<std::string> &exclude, std::string &errorString)
 {
     bool ret = true;
     std::ostringstream os;
@@ -238,7 +238,7 @@ bool FloodsWriter::WriteMesh_(const std::string &deviceName, const std::string &
     return ret;
 }
 
-bool FloodsWriter::WriteMeshes_(const std::string &filename, std::string &errorString)
+bool FloodsWriter::WriteMeshes_(const std::string &filename, std::vector<std::string> &include, std::vector<std::string> &exclude, std::string &errorString)
 {
     bool ret = true;
     std::ostringstream os;

--- a/src/meshing/FloodsWriter.hh
+++ b/src/meshing/FloodsWriter.hh
@@ -14,7 +14,7 @@ class FloodsWriter : public MeshWriter {
     public:
         ~FloodsWriter();
     private:
-        bool WriteMeshes_(const std::string &/*filename*/, std::string &/*errorString*/);
-        bool WriteMesh_(const std::string &/*deviceName*/, const std::string &/*filename*/, std::string &/*errorString*/);
+        bool WriteMeshes_(const std::string &/*filename*/, std::vector<std::string> &/*include*/, std::vector<std::string> &/*exclude*/, std::string &/*errorString*/);
+        bool WriteMesh_(const std::string &/*deviceName*/, const std::string &/*filename*/, std::vector<std::string> &/*include*/, std::vector<std::string> &/*exclude*/, std::string &/*errorString*/);
 };
 #endif

--- a/src/meshing/MeshWriter.cc
+++ b/src/meshing/MeshWriter.cc
@@ -9,13 +9,13 @@ SPDX-License-Identifier: Apache-2.0
 
 MeshWriter::~MeshWriter() {}
 
-bool MeshWriter::WriteMesh(const std::string &deviceName, const std::string &filename, std::string &errorString)
+bool MeshWriter::WriteMesh(const std::string &deviceName, const std::string &filename, std::vector<std::string> &include, std::vector<std::string> &exclude, std::string &errorString)
 {
-    return this->WriteMesh_(deviceName, filename, errorString);
+    return this->WriteMesh_(deviceName, filename, include, exclude, errorString);
 }
 
-bool MeshWriter::WriteMeshes(const std::string &filename, std::string &errorString)
+bool MeshWriter::WriteMeshes(const std::string &filename, std::vector<std::string> &include, std::vector<std::string> &exclude, std::string &errorString)
 {
-    return this->WriteMeshes_(filename, errorString);
+    return this->WriteMeshes_(filename, include, exclude, errorString);
 }
 

--- a/src/meshing/MeshWriter.hh
+++ b/src/meshing/MeshWriter.hh
@@ -8,16 +8,17 @@ SPDX-License-Identifier: Apache-2.0
 #ifndef MESH_WRITER_HH
 #define MESH_WRITER_HH
 #include <string>
+#include <vector>
 class MeshWriter
 {
     public:
         /// Start out by writing the all out to one file
         virtual ~MeshWriter() = 0;
-        bool WriteMeshes(const std::string &/*filename*/, std::string &/*errorString*/);
-        bool WriteMesh(const std::string &/*deviceName*/, const std::string &/*filename*/, std::string &/*errorString*/);
+        bool WriteMeshes(const std::string &/*filename*/, std::vector<std::string> &/*include*/, std::vector<std::string> &/*exclude*/, std::string &/*errorString*/);
+        bool WriteMesh(const std::string &/*deviceName*/, const std::string &/*filename*/, std::vector<std::string> &/*include*/, std::vector<std::string> &/*exclude*/, std::string &/*errorString*/);
     private:
-        virtual bool WriteMeshes_(const std::string &/*filename*/, std::string &/*errorString*/) = 0;
-        virtual bool WriteMesh_(const std::string &/*deviceName*/, const std::string &/*filename*/, std::string &/*errorString*/) = 0;
+        virtual bool WriteMeshes_(const std::string &/*filename*/, std::vector<std::string> &/*include*/, std::vector<std::string> &/*include*/, std::string &/*errorString*/) = 0;
+        virtual bool WriteMesh_(const std::string &/*deviceName*/, const std::string &/*filename*/, std::vector<std::string> &/*include*/, std::vector<std::string> &/*include*/, std::string &/*errorString*/) = 0;
 
 };
 #endif

--- a/src/meshing/TecplotWriter.hh
+++ b/src/meshing/TecplotWriter.hh
@@ -9,12 +9,13 @@ SPDX-License-Identifier: Apache-2.0
 #define TECPLOT_WRITER_HH
 #include "MeshWriter.hh"
 #include <string>
+#include <vector>
 /// Start out by writing the all out to one file
 class TecplotWriter : public MeshWriter {
     public:
         ~TecplotWriter();
     private:
-        bool WriteMeshes_(const std::string &/*filename*/, std::string &/*errorString*/);
-        bool WriteMesh_(const std::string &/*deviceName*/, const std::string &/*filename*/, std::string &/*errorString*/);
+        bool WriteMeshes_(const std::string &/*filename*/, std::vector<std::string> &/*include*/, std::vector<std::string> &/*exclude*/, std::string &/*errorString*/);
+        bool WriteMesh_(const std::string &/*deviceName*/, const std::string &/*filename*/, std::vector<std::string> &/*include*/, std::vector<std::string> &/*exclude*/, std::string &/*errorString*/);
 };
 #endif

--- a/src/meshing/VTKWriter.cc
+++ b/src/meshing/VTKWriter.cc
@@ -620,7 +620,7 @@ void WriteRegion(const Region &r, std::ostream &myfile)
 }
 #endif
 
-bool WriteSingleDevice(const std::string &dname, const std::string &filename, std::string &errorString)
+bool WriteSingleDevice(const std::string &dname, const std::string &filename, std::vector<std::string> &include, std::string &errorString)
 {
   bool ret = true;
   std::ostringstream os;
@@ -729,7 +729,7 @@ VTKWriter::~VTKWriter()
 {
 }
 
-bool VTKWriter::WriteMesh_(const std::string &deviceName, const std::string &filename, std::string &errorString)
+bool VTKWriter::WriteMesh_(const std::string &deviceName, const std::string &filename, std::vector<std::string> &include, std::vector<std::string> &exclude, std::string &errorString)
 {
     bool ret = true;
     std::ostringstream os;
@@ -745,7 +745,7 @@ bool VTKWriter::WriteMesh_(const std::string &deviceName, const std::string &fil
     else
     {
 #endif
-        ret = VTK::WriteSingleDevice(deviceName, filename, errorString);
+        ret = VTK::WriteSingleDevice(deviceName, filename, include, errorString);
 #if 0
     }
 #endif
@@ -753,7 +753,7 @@ bool VTKWriter::WriteMesh_(const std::string &deviceName, const std::string &fil
     return ret;
 }
 
-bool VTKWriter::WriteMeshes_(const std::string &filename, std::string &errorString)
+bool VTKWriter::WriteMeshes_(const std::string &filename, std::vector<std::string> &include, std::vector<std::string> &exclude, std::string &errorString)
 {
     bool ret = true;
     std::ostringstream os;
@@ -781,7 +781,7 @@ bool VTKWriter::WriteMeshes_(const std::string &filename, std::string &errorStri
         for (GlobalData::DeviceList_t::const_iterator dit = dlist.begin(); dit != dlist.end(); ++dit)
         {
             const std::string &dname = dit->first;
-            ret = VTK::WriteSingleDevice(dname, filename, errorString);
+            ret = VTK::WriteSingleDevice(dname, filename, include, errorString);
         }
     }
 #if 0

--- a/src/meshing/VTKWriter.hh
+++ b/src/meshing/VTKWriter.hh
@@ -9,12 +9,13 @@ SPDX-License-Identifier: Apache-2.0
 #define VTK_WRITER_HH
 #include "MeshWriter.hh"
 #include <string>
+#include <vector>
 /// Start out by writing the all out to one file
 class VTKWriter : public MeshWriter {
     public:
         ~VTKWriter();
     private:
-        bool WriteMeshes_(const std::string &/*filename*/, std::string &/*errorString*/);
-        bool WriteMesh_(const std::string &/*deviceName*/, const std::string &/*filename*/, std::string &/*errorString*/);
+        bool WriteMeshes_(const std::string &/*filename*/, std::vector<std::string> &/*include*/, std::vector<std::string> &/*exclude*/, std::string &/*errorString*/);
+        bool WriteMesh_(const std::string &/*deviceName*/, const std::string &/*filename*/, std::vector<std::string> &/*include*/, std::vector<std::string> &/*exclude*/, std::string &/*errorString*/);
 };
 #endif

--- a/src/pythonapi/DevsimDoc.cc
+++ b/src/pythonapi/DevsimDoc.cc
@@ -1027,7 +1027,7 @@ R"(    devsim.load_devices (file)
 )";
 
 static const char write_devices_doc[] =
-R"(    devsim.write_devices (file, device, type)
+R"(    devsim.write_devices (file, device, type, include, exclude)
 
     Write a device to a file for visualization or restart
 
@@ -1039,6 +1039,10 @@ R"(    devsim.write_devices (file, device, type)
        name of the device to write
     type : {'devsim', 'devsim_data', 'floops', 'tecplot', 'vtk'}
        format to use
+    include : Tuple[str], optional
+       Tuple of regex strings determining which fields to save. If unspecified, all fields are included. Currently only considered for type='tecplot'.
+    exclude : Tuple[str], optional
+       Tuple of regex strings determining which fields to ignore. If unspecified, no fields are excluded. Currently only considered for type='tecplot'.
 )";
 
 static const char contact_edge_model_doc[] =


### PR DESCRIPTION
Partially addresses #94 

Adds an `include` string argument to `write_devices` that is used to filter node and edge models when saving to TecPlot. `include `is a regular expression, and only node/edge model names matching the string will be saved. It defaults to `".*"` in order to recover legacy behaviour (save everything).

Limitations/possible improvements:
* The `include` argument  is currently not used for other file formats, but the same regex parsing could be added there too.
* The `include` argument is not used to filter out "global" data (x,y, etc.), but could be added there too.

### Example use and output, for the same device:

Command:

`ds.write_devices(file=file, device=device_name, type=type)`

Output file header:

```
TITLE = "450991316286470493"
VARIABLES = "x", "y", "Acceptors", "AtContactNode", "ContactSurfaceArea", "DEG", "Donors", "EC", "EC:Potential", "EFN", "EFN:Electrons", "EFN:Potential", "EFP", "EFP:Holes", "EFP:Potential", "EG", "EI", "EI:Potential", "EV", "EV:Potential", "ElectronGeneration", "ElectronGeneration:Electrons", "ElectronGeneration:Holes", "Electrons", "HoleGeneration", "HoleGeneration:Electrons", "HoleGeneration:Holes", "Holes", "IntrinsicCharge", "IntrinsicCharge:Potential", "IntrinsicElectrons", "IntrinsicElectrons:Potential", "IntrinsicHoles", "IntrinsicHoles:Potential", "NC", "NCharge", "NCharge:Electrons", "NIE", "NSurfaceNormal_x", "NSurfaceNormal_y", "NTOT", "NV", "NetDoping", "NodeVolume", "OptGen", "PCharge", "PCharge:Holes", "Potential", "PotentialIntrinsicCharge", "PotentialIntrinsicCharge:Potential", "PotentialNodeCharge", "PotentialNodeCharge:Electrons", "PotentialNodeCharge:Holes", "SurfaceArea", "Tn", "USRH_bulk", "USRH_bulk:Electrons", "USRH_bulk:Holes", "USRH_surface", "USRH_surface:Electrons", "USRH_surface:Holes", "V_t", "coordinate_index", "core___via@e_p1nodeelectrons", "core___via@e_p1nodeelectrons:Electrons", "core___via@e_p1nodeholes", "core___via@e_p1nodeholes:Holes", "core___via@e_p1nodemodel", "core___via@e_p1nodemodel:Potential", "ge___via@e_nnodeelectrons", "ge___via@e_nnodeelectrons:Electrons", "ge___via@e_nnodeholes", "ge___via@e_nnodeholes:Holes", "ge___via@e_nnodemodel", "ge___via@e_nnodemodel:Potential", "mu_n_node_lf", "mu_p_node_lf", "node_index", "region_box_at_bulk", "region_box_at_interface_core___box", "region_clad_at_bulk", "region_clad_at_interface_core___clad", "region_clad_at_interface_ge___clad", "region_core_at_bulk", "region_core_at_interface_core___box", "region_core_at_interface_core___clad", "region_core_at_interface_core___ge", "region_ge_at_bulk", "region_ge_at_interface_core___ge", "region_ge_at_interface_ge___clad", "region_via@e_n_at_bulk", "region_via@e_p1_at_bulk", "via@e_n___cladnodemodel", "via@e_n___cladnodemodel:Potential", "via@e_p1___cladnodemodel", "via@e_p1___cladnodemodel:Potential", "DField", "DField:Potential@n0", "DField:Potential@n1", "EField", "EField:Potential@n0", "EField:Potential@n1", "EdgeCouple", "EdgeInverseLength", "EdgeLength", "EdgeNodeVolume", "Electrons@n0", "Electrons@n1", "Epar_n", "Epar_n:Potential@n0", "Epar_n:Potential@n1", "Epar_p", "Epar_p:Potential@n0", "Epar_p:Potential@n1", "Holes@n0", "Holes@n1", "Jn", "Jn:Electrons@n0", "Jn:Electrons@n1", "Jn:Holes@n0", "Jn:Holes@n1", "Jn:Potential@n0", "Jn:Potential@n1", "Jn_arora_lf", "Jn_arora_lf:Electrons@n0", "Jn_arora_lf:Electrons@n1", "Jn_arora_lf:Holes@n0", "Jn_arora_lf:Holes@n1", "Jn_arora_lf:Potential@n0", "Jn_arora_lf:Potential@n1", "Jp", "Jp:Electrons@n0", "Jp:Electrons@n1", "Jp:Holes@n0", "Jp:Holes@n1", "Jp:Potential@n0", "Jp:Potential@n1", "Jp_arora_lf", "Jp_arora_lf:Electrons@n0", "Jp_arora_lf:Electrons@n1", "Jp_arora_lf:Holes@n0", "Jp_arora_lf:Holes@n1", "Jp_arora_lf:Potential@n0", "Jp_arora_lf:Potential@n1", "Potential@n0", "Potential@n1", "V_t_edge", "beta_n", "beta_p", "contactcharge_edge", "contactcharge_edge:Potential@n0", "contactcharge_edge:Potential@n1", "edge_index", "mu_arora_n_lf", "mu_arora_p_lf", "mu_n", "mu_n:Electrons@n0", "mu_n:Electrons@n1", "mu_n:Holes@n0", "mu_n:Holes@n1", "mu_n:Potential@n0", "mu_n:Potential@n1", "mu_p", "mu_p:Electrons@n0", "mu_p:Electrons@n1", "mu_p:Holes@n0", "mu_p:Holes@n1", "mu_p:Potential@n0", "mu_p:Potential@n1", "unitx", "unity", "vsat_n", "vsat_p", "EField_x", "EField_y", "ElementEdgeCouple", "ElementNodeVolume", "Emag", "Jn_x", "Jn_y", "Jnmag", "Jp_x", "Jp_y", "Jpmag"
```

Output filesize: 49.13MB

Command:

`ds.write_devices(file=file, device=device_name, type=type, include="Acceptors|Donors")`

Output file header:

```
TITLE = "450991316286470493"
VARIABLES = "x", "y", "Acceptors", "Donors", "EField_x", "EField_y", "ElementEdgeCouple", "ElementNodeVolume", "Emag", "Jn_x", "Jn_y", "Jnmag", "Jp_x", "Jp_y", "Jpmag"
```

Output filesize: 6.8MB




