### PR TITLE
ignore generated directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ testing/*.vtu
 testing/*.vtm
 testing/*.visit
 testing/*.msh
+
+# Ignore generated directories
+linux*/


### PR DESCRIPTION
git ignore some directories generated during building

Limitations/possible improvements:

* When building on other platforms, other directory names are probably used.