### PR TITLE
remove star imports

### DIFF
--- a/examples/bioapp1/bioapp1_2d.py
+++ b/examples/bioapp1/bioapp1_2d.py
@@ -6,7 +6,8 @@ global device
 device = "disk"
 
 import sys
-from devsim import *
+from devsim import add_gmsh_contact, add_gmsh_interface, add_gmsh_region, create_device, create_gmsh_mesh, finalize_mesh, node_model, node_solution, set_node_values, set_parameter, solve, write_devices
+
 
 if len(sys.argv) != 2:
     sys.stderr.write('must specify voltage')
@@ -29,7 +30,7 @@ add_gmsh_interface(mesh="disk", gmsh_name="dna_solution",        region0="dna", 
 finalize_mesh(mesh="disk")
 create_device(mesh="disk", device=device)
 
-from bioapp1_common import *
+import bioapp1_common
 
 set_parameter(device="disk", region="dna", name="charge_density", value=0)
 solve(type="dc", relative_error=1e-7, absolute_error=1e11, maximum_iterations=100)

--- a/examples/bioapp1/bioapp1_3d.py
+++ b/examples/bioapp1/bioapp1_3d.py
@@ -6,7 +6,8 @@ global device
 device = "disk"
 
 import sys
-from devsim import *
+from devsim import add_gmsh_contact, add_gmsh_interface, add_gmsh_region, create_device, create_gmsh_mesh, finalize_mesh, node_model, node_solution, set_node_values, set_parameter, solve, write_devices
+
 
 if len(sys.argv) != 2:
     sys.stderr.write('must specify voltage')
@@ -29,7 +30,8 @@ add_gmsh_interface(mesh="disk", gmsh_name="dna_solution",        region0="dna", 
 finalize_mesh(mesh="disk")
 create_device(mesh="disk", device=device)
 
-from bioapp1_common import *
+import bioapp1_common
+# from bioapp1_common import *
 
 set_parameter(device="disk", region="dna", name="charge_density", value=0)
 solve(type="dc", relative_error=1e-7, absolute_error=1e11, maximum_iterations=100)

--- a/examples/bioapp1/bioapp1_common.py
+++ b/examples/bioapp1/bioapp1_common.py
@@ -2,7 +2,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from devsim import *
+from devsim import add_db_entry, contact_equation, contact_node_model, create_db, cylindrical_edge_couple, cylindrical_node_volume, edge_from_node_model, edge_model, element_from_edge_model, equation, get_dimension, get_node_model_values, interface_equation, interface_model, node_model, node_solution, set_node_values, set_parameter
+
 #### molarity 0.001 mole / Liter * 1 L / (1e3 cm^3) * 6.02e23 / mole = 6.02e17 /cm^3
 set_parameter(device="disk", region="solution", name="n_bound", value=6.02e17)
 #### 2q/nm^3 -->  2/nm^3 * (1 nm^3/(1e-7 cm)^3)

--- a/examples/capacitance/cap1d.py
+++ b/examples/capacitance/cap1d.py
@@ -2,7 +2,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from devsim import *
+from devsim import add_1d_contact, add_1d_mesh_line, add_1d_region, contact_equation, contact_node_model, create_1d_mesh, create_device, edge_from_node_model, edge_model, equation, finalize_mesh, get_contact_charge, node_solution, set_parameter, solve
+
 device="MyDevice"
 region="MyRegion"
 

--- a/examples/capacitance/cap2d.py
+++ b/examples/capacitance/cap2d.py
@@ -2,7 +2,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from devsim import *
+from devsim import add_2d_contact, add_2d_mesh_line, add_2d_region, contact_equation, contact_node_model, create_2d_mesh, create_device, edge_from_node_model, edge_model, element_from_edge_model, equation, finalize_mesh, get_contact_charge, node_model, node_solution, set_parameter, solve, write_devices
+
 device="MyDevice"
 region="MyRegion"
 

--- a/examples/diode/diode_1d.py
+++ b/examples/diode/diode_1d.py
@@ -2,7 +2,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from devsim import *
+from devsim import print_node_values, set_parameter, solve, write_devices
+
 import devsim.python_packages.simple_physics as simple_physics
 import diode_common
 #####

--- a/examples/diode/diode_1d_custom.py
+++ b/examples/diode/diode_1d_custom.py
@@ -2,7 +2,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from devsim import *
+from devsim import custom_equation, get_element_node_list, get_equation_numbers, get_node_model_values, get_parameter, node_model, print_node_values, set_parameter, solve, write_devices
+
 import devsim.python_packages.simple_physics as simple_physics
 import diode_common
 #####

--- a/examples/diode/diode_2d.py
+++ b/examples/diode/diode_2d.py
@@ -2,8 +2,9 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from devsim import *
-from devsim.python_packages.simple_physics import *
+from devsim import set_parameter, solve
+
+from devsim.python_packages.simple_physics import GetContactBiasName, PrintCurrents
 import diode_common
 
 # dio1

--- a/examples/diode/diode_common.py
+++ b/examples/diode/diode_common.py
@@ -2,8 +2,11 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from devsim import *
-from devsim.python_packages.simple_physics import *
+from devsim import add_1d_contact, add_1d_mesh_line, add_1d_region, add_2d_contact, add_2d_mesh_line, add_2d_region, add_gmsh_contact, add_gmsh_region, create_1d_mesh, create_2d_mesh, create_device, create_gmsh_mesh, finalize_mesh, get_contact_list, set_node_values, set_parameter
+
+from devsim.python_packages.model_create import CreateNodeModel, CreateSolution
+
+from devsim.python_packages.simple_physics import GetContactBiasName, SetSiliconParameters, CreateSiliconPotentialOnly, CreateSiliconPotentialOnlyContact, CreateSiliconDriftDiffusion, CreateSiliconDriftDiffusionAtContact
 #####
 # dio1
 #

--- a/examples/diode/gmsh_diode2d.py
+++ b/examples/diode/gmsh_diode2d.py
@@ -2,8 +2,9 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from devsim import *
-from devsim.python_packages.simple_physics import *
+from devsim import node_model, set_parameter, solve, write_devices
+
+from devsim.python_packages.simple_physics import GetContactBiasName, PrintCurrents
 import diode_common
 
 device="diode2d"

--- a/examples/diode/gmsh_diode3d.py
+++ b/examples/diode/gmsh_diode3d.py
@@ -2,8 +2,9 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from devsim import *
-from devsim.python_packages.simple_physics import *
+from devsim import element_from_edge_model, node_model, set_parameter, solve, write_devices
+
+from devsim.python_packages.simple_physics import GetContactBiasName, PrintCurrents
 import diode_common
 
 device="diode3d"

--- a/examples/diode/gmsh_diode3d_equil.py
+++ b/examples/diode/gmsh_diode3d_equil.py
@@ -4,8 +4,7 @@
 
 # this test added specifically to create a mesh for gmsh_diode3d_equil.py
 
-from devsim import *
-from devsim.python_packages.simple_physics import *
+from devsim import node_model, solve, write_devices
 import diode_common
 
 device="diode3d"

--- a/examples/diode/gmsh_diode3d_float128.py
+++ b/examples/diode/gmsh_diode3d_float128.py
@@ -3,7 +3,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import sys
-from devsim import *
+from devsim import element_from_edge_model, get_parameter, node_model, set_parameter, solve, write_devices
+
 
 if not get_parameter(name='info')['extended_precision']:
     print("Extended precision support is not available with this version")
@@ -13,7 +14,7 @@ set_parameter(name = "extended_solver", value=True)
 set_parameter(name = "extended_model", value=True)
 set_parameter(name = "extended_equation", value=True)
 
-from devsim.python_packages.simple_physics import *
+from devsim.python_packages.simple_physics import GetContactBiasName, PrintCurrents
 import diode_common
 
 device="diode3d"

--- a/examples/diode/laux2d.py
+++ b/examples/diode/laux2d.py
@@ -32,8 +32,9 @@ except:
     sys.exit(-1)
 
 
-from devsim import *
-from laux_common import *
+from devsim import load_devices
+
+from laux_common import SetDimension, RunTest
 
 
 load_devices(file="gmsh_diode2d_dd.msh")

--- a/examples/diode/laux3d.py
+++ b/examples/diode/laux3d.py
@@ -32,8 +32,9 @@ except:
     sys.exit(-1)
 
 
-from devsim import *
-from laux_common import *
+from devsim import load_devices
+
+from laux_common import SetDimension, RunTest
 import laux_common
 
 

--- a/examples/diode/laux_common.py
+++ b/examples/diode/laux_common.py
@@ -34,7 +34,8 @@ except:
     sys.exit(0)
 
 
-from devsim import *
+from devsim import element_from_edge_model, element_from_node_model, element_model, element_pair_from_edge_model, get_element_model_values
+
 
 dim = None
 nee = None

--- a/examples/diode/pythonmesh3d.py
+++ b/examples/diode/pythonmesh3d.py
@@ -1,4 +1,5 @@
-from devsim import *
+from devsim import add_gmsh_contact, add_gmsh_region, create_device, create_gmsh_mesh, finalize_mesh, write_devices
+
 import devsim.python_packages.pythonmesh
 
 

--- a/examples/diode/ssac_diode.py
+++ b/examples/diode/ssac_diode.py
@@ -3,8 +3,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 #### Small Signal simulation
-from devsim import *
-from devsim.python_packages.simple_physics import *
+from devsim import circuit_alter, circuit_element, get_circuit_node_list, get_circuit_node_value, get_circuit_solution_list, solve
+
+from devsim.python_packages.simple_physics import GetContactBiasName, PrintCurrents
 import diode_common
 import math
 

--- a/examples/diode/tran_diode.py
+++ b/examples/diode/tran_diode.py
@@ -1,5 +1,5 @@
 import devsim
-from devsim.python_packages.simple_physics import *
+from devsim.python_packages.simple_physics import GetContactBiasName
 import diode_common
 
 def print_circuit_solution():

--- a/examples/mobility/gmsh_mos2d.py
+++ b/examples/mobility/gmsh_mos2d.py
@@ -2,11 +2,11 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from devsim.python_packages.simple_physics import *
-from devsim.python_packages.ramp import *
-from devsim import *
+from devsim.python_packages.simple_physics import GetContactBiasName, SetOxideParameters, SetSiliconParameters, CreateSiliconPotentialOnly, CreateSiliconPotentialOnlyContact, CreateSiliconDriftDiffusion, CreateSiliconDriftDiffusionAtContact, CreateOxidePotentialOnly, CreateSiliconOxideInterface
+from devsim.python_packages.ramp import rampbias, printAllCurrents
+from devsim import element_from_edge_model, get_contact_list, get_region_list, node_model, set_node_values, set_parameter, solve, write_devices
+from devsim.python_packages.model_create import CreateSolution
 
-import gmsh_mos2d_create
 device = "mos2d"
 silicon_regions=("gate", "bulk")
 oxide_regions=("oxide",)

--- a/examples/mobility/gmsh_mos2d_create.py
+++ b/examples/mobility/gmsh_mos2d_create.py
@@ -2,7 +2,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from devsim import *
+from devsim import add_gmsh_contact, add_gmsh_interface, add_gmsh_region, create_device, create_gmsh_mesh, finalize_mesh, node_model, write_devices
+
 device ="mos2d"
 
 device_width    =1.0e-4

--- a/examples/mobility/gmsh_mos2d_kla.py
+++ b/examples/mobility/gmsh_mos2d_kla.py
@@ -4,12 +4,15 @@
 
 #set_parameter -name threads_available -value 1
 #set_parameter -name threads_task_size -value 1024
+from devsim import get_contact_list, get_parameter, get_region_list, node_model, set_node_values, set_parameter, solve, vector_element_model, write_devices
+
+from devsim.python_packages.simple_physics import GetContactBiasName, SetOxideParameters, SetSiliconParameters, CreateSiliconPotentialOnly, CreateSiliconPotentialOnlyContact, CreateSiliconDriftDiffusion, CreateSiliconDriftDiffusionAtContact, CreateOxidePotentialOnly, CreateSiliconOxideInterface
+from devsim.python_packages.ramp import rampbias, printAllCurrents
+from devsim.python_packages.Klaassen import Set_Mobility_Parameters, Klaassen_Mobility, Philips_VelocitySaturation, Philips_Surface_Mobility
+from devsim.python_packages.mos_physics import CreateElementElectronContinuityEquation, CreateElementContactElectronContinuityEquation, CreateNormalElectricFieldFromCurrentFlow, CreateElementElectronCurrent2d
+from devsim.python_packages.model_create import CreateSolution, CreateElementModel2d
+
 import gmsh_mos2d_create
-from devsim import *
-from devsim.python_packages.simple_physics import *
-from devsim.python_packages.ramp import *
-from devsim.python_packages.Klaassen import *
-from devsim.python_packages.mos_physics import *
 
 # TODO: write out mesh, and then read back in as separate test
 device = "mos2d"

--- a/examples/mobility/pythonmesh2d.py
+++ b/examples/mobility/pythonmesh2d.py
@@ -1,4 +1,5 @@
-from devsim import *
+from devsim import add_gmsh_contact, add_gmsh_interface, add_gmsh_region, create_device, create_gmsh_mesh, finalize_mesh, write_devices
+
 import devsim.python_packages.pythonmesh
 
 def gmsh_reader(mesh, device, filename="", coordinates="", physical_names="", elements=""):

--- a/examples/vectorpotential/twowire.py
+++ b/examples/vectorpotential/twowire.py
@@ -2,7 +2,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from devsim import *
+from devsim import add_gmsh_contact, add_gmsh_interface, add_gmsh_region, contact_equation, contact_node_model, create_device, create_gmsh_mesh, edge_from_node_model, edge_model, equation, finalize_mesh, get_element_model_values, get_node_model_values, interface_equation, interface_model, node_model, node_solution, set_parameter, solve, vector_gradient, write_devices
+
 device="twowire"
 
 create_gmsh_mesh(file="twowire.msh", mesh="twowire")

--- a/python_packages/Klaassen.py
+++ b/python_packages/Klaassen.py
@@ -2,8 +2,9 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from devsim import *
-from devsim.python_packages.model_create import *
+from devsim import set_parameter
+
+from devsim.python_packages.model_create import CreateNodeModel, CreateNodeModelDerivative, CreateEdgeModel, CreateElementModel2d, CreateElementModelDerivative2d, CreateGeometricMean, CreateGeometricMeanDerivative
 
 def Set_Mobility_Parameters(device, region):
     #As

--- a/python_packages/model_create.py
+++ b/python_packages/model_create.py
@@ -2,7 +2,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from devsim import *
+from devsim import contact_edge_model, contact_node_model, edge_average_model, edge_from_node_model, edge_model, element_model, get_edge_model_list, get_node_model_list, interface_model, node_model, node_solution
+
 debug = False
 def CreateSolution(device, region, name):
     '''

--- a/python_packages/mos_physics.py
+++ b/python_packages/mos_physics.py
@@ -2,8 +2,9 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from devsim import *
-from devsim.python_packages.model_create import *
+from devsim import contact_equation, element_from_edge_model, equation, get_dimension
+
+from devsim.python_packages.model_create import CreateElementModel2d, CreateElementModelDerivative2d
 
 def CreateElementElectronContinuityEquation(device, region, current_model):
     '''

--- a/python_packages/pythonmesh.py
+++ b/python_packages/pythonmesh.py
@@ -1,4 +1,4 @@
-from devsim import *
+
 
 def parse_gmsh_file(file):
     sections=set(['$MeshFormat', '$PhysicalNames', '$Nodes', '$Elements'])

--- a/python_packages/ramp.py
+++ b/python_packages/ramp.py
@@ -2,9 +2,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import sys
 import devsim as ds
-from .simple_physics import *
+from devsim.python_packages.simple_physics import GetContactBiasName, PrintCurrents
 
 def rampbias(device, contact, end_bias, step_size, min_step, max_iter, rel_error, abs_error, callback):
     '''

--- a/python_packages/simple_dd.py
+++ b/python_packages/simple_dd.py
@@ -2,7 +2,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from .model_create import *
+from devsim.python_packages.model_create import CreateEdgeModel, CreateEdgeModelDerivatives, InEdgeModelList, EnsureEdgeFromNodeModelExists
+
 def CreateBernoulli (device, region):
     '''
     Creates the Bernoulli function for Scharfetter Gummel

--- a/python_packages/simple_physics.py
+++ b/python_packages/simple_physics.py
@@ -2,8 +2,10 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from .simple_dd import *
-from devsim import *
+from .simple_dd import CreateBernoulli, CreateElectronCurrent, CreateHoleCurrent
+
+from devsim import contact_equation, equation, get_contact_current, get_parameter, interface_equation, set_parameter
+
 contactcharge_edge="contactcharge_edge"
 ece_name="ElectronContinuityEquation"
 hce_name="HoleContinuityEquation"

--- a/src/commands/MeshingCommands.cc
+++ b/src/commands/MeshingCommands.cc
@@ -811,8 +811,6 @@ writeDevicesCmd(CommandHandler &data)
         }
     }
 
-    
-
     std::unique_ptr<MeshWriter> mw;
 
     if (type.empty() || (type == "devsim"))

--- a/src/meshing/DevsimRestartWriter.cc
+++ b/src/meshing/DevsimRestartWriter.cc
@@ -398,7 +398,7 @@ DevsimRestartWriter::~DevsimRestartWriter()
 {
 }
 
-bool DevsimRestartWriter::WriteMesh_(const std::string &deviceName, const std::string &filename, std::string &errorString)
+bool DevsimRestartWriter::WriteMesh_(const std::string &deviceName, const std::string &filename, std::vector<std::string> &include, std::vector<std::string> &exclude, std::string &errorString)
 {
     bool ret = true;
     std::ostringstream os;
@@ -418,7 +418,7 @@ bool DevsimRestartWriter::WriteMesh_(const std::string &deviceName, const std::s
     return ret;
 }
 
-bool DevsimRestartWriter::WriteMeshes_(const std::string &filename, std::string &errorString)
+bool DevsimRestartWriter::WriteMeshes_(const std::string &filename, std::vector<std::string> &include, std::vector<std::string> &exclude, std::string &errorString)
 {
     bool ret = true;
     std::ostringstream os;

--- a/src/meshing/DevsimRestartWriter.hh
+++ b/src/meshing/DevsimRestartWriter.hh
@@ -9,12 +9,13 @@ SPDX-License-Identifier: Apache-2.0
 #define DEVSIM_RESTART_WRITER_HH
 #include "MeshWriter.hh"
 #include <string>
+#include <vector>
 /// Start out by writing the all out to one file
 class DevsimRestartWriter : public MeshWriter {
     public:
         ~DevsimRestartWriter();
     private:
-        bool WriteMeshes_(const std::string &/*filename*/, std::string &/*errorString*/);
-        bool WriteMesh_(const std::string &/*deviceName*/, const std::string &/*filename*/, std::string &/*errorString*/);
+        bool WriteMeshes_(const std::string &/*filename*/, std::vector<std::string> &/*include*/, std::vector<std::string> &/*exclude*/, std::string &/*errorString*/);
+        bool WriteMesh_(const std::string &/*deviceName*/, const std::string &/*filename*/, std::vector<std::string> &/*include*/, std::vector<std::string> &/*exclude*/, std::string &/*errorString*/);
 };
 #endif

--- a/src/meshing/DevsimWriter.cc
+++ b/src/meshing/DevsimWriter.cc
@@ -237,7 +237,7 @@ DevsimWriter::~DevsimWriter()
 {
 }
 
-bool DevsimWriter::WriteMesh_(const std::string &deviceName, const std::string &filename, std::string &errorString)
+bool DevsimWriter::WriteMesh_(const std::string &deviceName, const std::string &filename, std::vector<std::string> &include, std::vector<std::string> &exclude, std::string &errorString)
 {
     bool ret = true;
     std::ostringstream os;
@@ -257,7 +257,7 @@ bool DevsimWriter::WriteMesh_(const std::string &deviceName, const std::string &
     return ret;
 }
 
-bool DevsimWriter::WriteMeshes_(const std::string &filename, std::string &errorString)
+bool DevsimWriter::WriteMeshes_(const std::string &filename, std::vector<std::string> &include, std::vector<std::string> &exclude, std::string &errorString)
 {
     bool ret = true;
     std::ostringstream os;

--- a/src/meshing/DevsimWriter.hh
+++ b/src/meshing/DevsimWriter.hh
@@ -9,12 +9,13 @@ SPDX-License-Identifier: Apache-2.0
 #define DEVSIM_WRITER_HH
 #include "MeshWriter.hh"
 #include <string>
+#include <vector>
 /// Start out by writing the all out to one file
 class DevsimWriter : public MeshWriter {
     public:
         ~DevsimWriter();
     private:
-        bool WriteMeshes_(const std::string &/*filename*/, std::string &/*errorString*/);
-        bool WriteMesh_(const std::string &/*deviceName*/, const std::string &/*filename*/, std::string &/*errorString*/);
+        bool WriteMeshes_(const std::string &/*filename*/, std::vector<std::string> &/*include*/, std::vector<std::string> &/*exclude*/, std::string &/*errorString*/);
+        bool WriteMesh_(const std::string &/*deviceName*/, const std::string &/*filename*/, std::vector<std::string> &/*include*/, std::vector<std::string> &/*exclude*/, std::string &/*errorString*/);
 };
 #endif

--- a/src/meshing/FloodsWriter.cc
+++ b/src/meshing/FloodsWriter.cc
@@ -218,7 +218,7 @@ FloodsWriter::~FloodsWriter()
 {
 }
 
-bool FloodsWriter::WriteMesh_(const std::string &deviceName, const std::string &filename, std::string &errorString)
+bool FloodsWriter::WriteMesh_(const std::string &deviceName, const std::string &filename, std::vector<std::string> &include, std::vector<std::string> &exclude, std::string &errorString)
 {
     bool ret = true;
     std::ostringstream os;
@@ -238,7 +238,7 @@ bool FloodsWriter::WriteMesh_(const std::string &deviceName, const std::string &
     return ret;
 }
 
-bool FloodsWriter::WriteMeshes_(const std::string &filename, std::string &errorString)
+bool FloodsWriter::WriteMeshes_(const std::string &filename, std::vector<std::string> &include, std::vector<std::string> &exclude, std::string &errorString)
 {
     bool ret = true;
     std::ostringstream os;

--- a/src/meshing/FloodsWriter.hh
+++ b/src/meshing/FloodsWriter.hh
@@ -14,7 +14,7 @@ class FloodsWriter : public MeshWriter {
     public:
         ~FloodsWriter();
     private:
-        bool WriteMeshes_(const std::string &/*filename*/, std::string &/*errorString*/);
-        bool WriteMesh_(const std::string &/*deviceName*/, const std::string &/*filename*/, std::string &/*errorString*/);
+        bool WriteMeshes_(const std::string &/*filename*/, std::vector<std::string> &/*include*/, std::vector<std::string> &/*exclude*/, std::string &/*errorString*/);
+        bool WriteMesh_(const std::string &/*deviceName*/, const std::string &/*filename*/, std::vector<std::string> &/*include*/, std::vector<std::string> &/*exclude*/, std::string &/*errorString*/);
 };
 #endif

--- a/src/meshing/MeshWriter.cc
+++ b/src/meshing/MeshWriter.cc
@@ -9,13 +9,13 @@ SPDX-License-Identifier: Apache-2.0
 
 MeshWriter::~MeshWriter() {}
 
-bool MeshWriter::WriteMesh(const std::string &deviceName, const std::string &filename, std::string &errorString)
+bool MeshWriter::WriteMesh(const std::string &deviceName, const std::string &filename, std::vector<std::string> &include, std::vector<std::string> &exclude, std::string &errorString)
 {
-    return this->WriteMesh_(deviceName, filename, errorString);
+    return this->WriteMesh_(deviceName, filename, include, exclude, errorString);
 }
 
-bool MeshWriter::WriteMeshes(const std::string &filename, std::string &errorString)
+bool MeshWriter::WriteMeshes(const std::string &filename, std::vector<std::string> &include, std::vector<std::string> &exclude, std::string &errorString)
 {
-    return this->WriteMeshes_(filename, errorString);
+    return this->WriteMeshes_(filename, include, exclude, errorString);
 }
 

--- a/src/meshing/MeshWriter.hh
+++ b/src/meshing/MeshWriter.hh
@@ -8,16 +8,17 @@ SPDX-License-Identifier: Apache-2.0
 #ifndef MESH_WRITER_HH
 #define MESH_WRITER_HH
 #include <string>
+#include <vector>
 class MeshWriter
 {
     public:
         /// Start out by writing the all out to one file
         virtual ~MeshWriter() = 0;
-        bool WriteMeshes(const std::string &/*filename*/, std::string &/*errorString*/);
-        bool WriteMesh(const std::string &/*deviceName*/, const std::string &/*filename*/, std::string &/*errorString*/);
+        bool WriteMeshes(const std::string &/*filename*/, std::vector<std::string> &/*include*/, std::vector<std::string> &/*exclude*/, std::string &/*errorString*/);
+        bool WriteMesh(const std::string &/*deviceName*/, const std::string &/*filename*/, std::vector<std::string> &/*include*/, std::vector<std::string> &/*exclude*/, std::string &/*errorString*/);
     private:
-        virtual bool WriteMeshes_(const std::string &/*filename*/, std::string &/*errorString*/) = 0;
-        virtual bool WriteMesh_(const std::string &/*deviceName*/, const std::string &/*filename*/, std::string &/*errorString*/) = 0;
+        virtual bool WriteMeshes_(const std::string &/*filename*/, std::vector<std::string> &/*include*/, std::vector<std::string> &/*include*/, std::string &/*errorString*/) = 0;
+        virtual bool WriteMesh_(const std::string &/*deviceName*/, const std::string &/*filename*/, std::vector<std::string> &/*include*/, std::vector<std::string> &/*include*/, std::string &/*errorString*/) = 0;
 
 };
 #endif

--- a/src/meshing/TecplotWriter.hh
+++ b/src/meshing/TecplotWriter.hh
@@ -9,12 +9,13 @@ SPDX-License-Identifier: Apache-2.0
 #define TECPLOT_WRITER_HH
 #include "MeshWriter.hh"
 #include <string>
+#include <vector>
 /// Start out by writing the all out to one file
 class TecplotWriter : public MeshWriter {
     public:
         ~TecplotWriter();
     private:
-        bool WriteMeshes_(const std::string &/*filename*/, std::string &/*errorString*/);
-        bool WriteMesh_(const std::string &/*deviceName*/, const std::string &/*filename*/, std::string &/*errorString*/);
+        bool WriteMeshes_(const std::string &/*filename*/, std::vector<std::string> &/*include*/, std::vector<std::string> &/*exclude*/, std::string &/*errorString*/);
+        bool WriteMesh_(const std::string &/*deviceName*/, const std::string &/*filename*/, std::vector<std::string> &/*include*/, std::vector<std::string> &/*exclude*/, std::string &/*errorString*/);
 };
 #endif

--- a/src/meshing/VTKWriter.cc
+++ b/src/meshing/VTKWriter.cc
@@ -620,7 +620,7 @@ void WriteRegion(const Region &r, std::ostream &myfile)
 }
 #endif
 
-bool WriteSingleDevice(const std::string &dname, const std::string &filename, std::string &errorString)
+bool WriteSingleDevice(const std::string &dname, const std::string &filename, std::vector<std::string> &include, std::string &errorString)
 {
   bool ret = true;
   std::ostringstream os;
@@ -729,7 +729,7 @@ VTKWriter::~VTKWriter()
 {
 }
 
-bool VTKWriter::WriteMesh_(const std::string &deviceName, const std::string &filename, std::string &errorString)
+bool VTKWriter::WriteMesh_(const std::string &deviceName, const std::string &filename, std::vector<std::string> &include, std::vector<std::string> &exclude, std::string &errorString)
 {
     bool ret = true;
     std::ostringstream os;
@@ -745,7 +745,7 @@ bool VTKWriter::WriteMesh_(const std::string &deviceName, const std::string &fil
     else
     {
 #endif
-        ret = VTK::WriteSingleDevice(deviceName, filename, errorString);
+        ret = VTK::WriteSingleDevice(deviceName, filename, include, errorString);
 #if 0
     }
 #endif
@@ -753,7 +753,7 @@ bool VTKWriter::WriteMesh_(const std::string &deviceName, const std::string &fil
     return ret;
 }
 
-bool VTKWriter::WriteMeshes_(const std::string &filename, std::string &errorString)
+bool VTKWriter::WriteMeshes_(const std::string &filename, std::vector<std::string> &include, std::vector<std::string> &exclude, std::string &errorString)
 {
     bool ret = true;
     std::ostringstream os;
@@ -781,7 +781,7 @@ bool VTKWriter::WriteMeshes_(const std::string &filename, std::string &errorStri
         for (GlobalData::DeviceList_t::const_iterator dit = dlist.begin(); dit != dlist.end(); ++dit)
         {
             const std::string &dname = dit->first;
-            ret = VTK::WriteSingleDevice(dname, filename, errorString);
+            ret = VTK::WriteSingleDevice(dname, filename, include, errorString);
         }
     }
 #if 0

--- a/src/meshing/VTKWriter.hh
+++ b/src/meshing/VTKWriter.hh
@@ -9,12 +9,13 @@ SPDX-License-Identifier: Apache-2.0
 #define VTK_WRITER_HH
 #include "MeshWriter.hh"
 #include <string>
+#include <vector>
 /// Start out by writing the all out to one file
 class VTKWriter : public MeshWriter {
     public:
         ~VTKWriter();
     private:
-        bool WriteMeshes_(const std::string &/*filename*/, std::string &/*errorString*/);
-        bool WriteMesh_(const std::string &/*deviceName*/, const std::string &/*filename*/, std::string &/*errorString*/);
+        bool WriteMeshes_(const std::string &/*filename*/, std::vector<std::string> &/*include*/, std::vector<std::string> &/*exclude*/, std::string &/*errorString*/);
+        bool WriteMesh_(const std::string &/*deviceName*/, const std::string &/*filename*/, std::vector<std::string> &/*include*/, std::vector<std::string> &/*exclude*/, std::string &/*errorString*/);
 };
 #endif

--- a/src/pythonapi/DevsimDoc.cc
+++ b/src/pythonapi/DevsimDoc.cc
@@ -1027,7 +1027,7 @@ R"(    devsim.load_devices (file)
 )";
 
 static const char write_devices_doc[] =
-R"(    devsim.write_devices (file, device, type)
+R"(    devsim.write_devices (file, device, type, include, exclude)
 
     Write a device to a file for visualization or restart
 
@@ -1039,6 +1039,10 @@ R"(    devsim.write_devices (file, device, type)
        name of the device to write
     type : {'devsim', 'devsim_data', 'floops', 'tecplot', 'vtk'}
        format to use
+    include : Tuple[str], optional
+       Tuple of regex strings determining which fields to save. If unspecified, all fields are included. Currently only considered for type='tecplot'.
+    exclude : Tuple[str], optional
+       Tuple of regex strings determining which fields to ignore. If unspecified, no fields are excluded. Currently only considered for type='tecplot'.
 )";
 
 static const char contact_edge_model_doc[] =

--- a/testing/Fermi1_float128.py
+++ b/testing/Fermi1_float128.py
@@ -16,4 +16,3 @@ devsim.set_parameter(name = "extended_model", value=True)
 devsim.set_parameter(name = "extended_equation", value=True)
 
 import Fermi1
-

--- a/testing/GaussFermi_float128.py
+++ b/testing/GaussFermi_float128.py
@@ -5,7 +5,6 @@
 #Purpose: Fermi integral and inverse
 
 import devsim
-import test_common
 import sys
 
 if not devsim.get_parameter(name='info')['extended_precision']:
@@ -17,4 +16,3 @@ devsim.set_parameter(name = "extended_model", value=True)
 devsim.set_parameter(name = "extended_equation", value=True)
 
 import GaussFermi
-

--- a/testing/cap2.py
+++ b/testing/cap2.py
@@ -6,7 +6,8 @@
 #### cap2.py
 #### tests physics of cap made of two insulating regions
 ####
-from devsim import *
+from devsim import add_1d_contact, add_1d_interface, add_1d_mesh_line, add_1d_region, contact_equation, create_1d_mesh, create_device, delete_contact_equation, delete_edge_model, delete_equation, delete_interface_equation, delete_interface_model, delete_node_model, edge_from_node_model, edge_model, edge_solution, equation, finalize_mesh, get_contact_charge, get_contact_equation_command, get_contact_equation_list, get_contact_list, get_edge_model_values, get_equation_command, get_equation_list, get_interface_equation_command, get_interface_equation_list, get_interface_list, get_node_model_values, get_region_list, interface_equation, interface_model, node_model, node_solution, print_edge_values, print_node_values, set_edge_values, set_node_value, set_node_values, set_parameter, solve
+
 device="MyDevice"
 interface="MySiOx"
 regions =("MyOxRegion", "MySiRegion")

--- a/testing/cap_mesh.py
+++ b/testing/cap_mesh.py
@@ -2,7 +2,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from devsim import *
+from devsim import add_1d_contact, add_1d_mesh_line, add_1d_region, create_1d_mesh, finalize_mesh
+
 def cap_mesh(region_name, material_name):
     '''
       Creates a simple cap mesh named cap1 for test purposes with a given region name

--- a/testing/equation1.py
+++ b/testing/equation1.py
@@ -2,7 +2,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from devsim import *
+from devsim import add_circuit_node, circuit_alter, circuit_element, custom_equation, get_circuit_equation_number, get_circuit_node_value, solve
+
 import test_common
 # basic linear circuit solved by itself
 add_circuit_node(name="n1", variable_update="default")

--- a/testing/kahan_float128.py
+++ b/testing/kahan_float128.py
@@ -5,7 +5,6 @@
 #Purpose: Fermi integral and inverse
 
 import devsim
-import test_common
 import sys
 
 if not devsim.get_parameter(name='info')['extended_precision']:
@@ -17,4 +16,3 @@ devsim.set_parameter(name = "extended_model", value=True)
 devsim.set_parameter(name = "extended_equation", value=True)
 
 import kahan
-

--- a/testing/laux1.py
+++ b/testing/laux1.py
@@ -32,7 +32,8 @@ except:
     sys.exit(-1)
 
 
-from devsim import *
+from devsim import edge_from_node_model, element_from_edge_model, element_from_node_model, element_model, get_edge_model_values, get_element_model_values, load_devices
+
 
 def calculateValues(scalar_efield, eecouple, sx, sy):
     '''

--- a/testing/mos_2d.py
+++ b/testing/mos_2d.py
@@ -2,9 +2,9 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from devsim.python_packages.simple_physics import *
-from devsim.python_packages.ramp import *
-from devsim import *
+from devsim.python_packages.simple_physics import GetContactBiasName, SetOxideParameters, SetSiliconParameters, CreateSiliconPotentialOnly, CreateSiliconPotentialOnlyContact, CreateSiliconDriftDiffusion, CreateSiliconDriftDiffusionAtContact, CreateOxidePotentialOnly, CreateSiliconOxideInterface
+from devsim.python_packages.model_create import CreateSolution
+from devsim import get_contact_list, get_device_list, get_parameter, get_parameter_list, get_region_list, node_model, set_node_values, set_parameter, solve, write_devices
 
 import mos_2d_create
 

--- a/testing/mos_2d_restart.py
+++ b/testing/mos_2d_restart.py
@@ -3,9 +3,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import devsim
+from devsim import get_contact_list, get_region_list, set_parameter, set_node_values
+from devsim.python_packages.model_create import CreateSolution
+
 devsim.load_devices(file="mos_2d_dd.msh")
 device=devsim.get_device_list()[0]
-from devsim.python_packages.simple_physics import *
+from devsim.python_packages.simple_physics import GetContactBiasName, SetOxideParameters, SetSiliconParameters, CreateSiliconPotentialOnly, CreateSiliconPotentialOnlyContact, CreateSiliconDriftDiffusion, CreateSiliconDriftDiffusionAtContact, CreateOxidePotentialOnly, CreateSiliconOxideInterface
 
 device = "mymos"
 silicon_regions=("gate", "bulk")

--- a/testing/ptest1.py
+++ b/testing/ptest1.py
@@ -2,7 +2,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from cap_mesh import *
+from devsim import create_device, get_contact_charge, get_edge_model_values, set_parameter, solve
+from cap_mesh import cap_mesh
 
 region_name = "MyRegion"
 device_name = "MyDevice"
@@ -11,7 +12,7 @@ material_name = "Oxide"
 mesh_name = cap_mesh(region_name, material_name)
 create_device(mesh=mesh_name, device=device_name)
 
-from devsim.python_packages.simple_physics import *
+from devsim.python_packages.simple_physics import CreateOxideContact, SetOxideParameters, CreateOxidePotentialOnly
 
 SetOxideParameters(device_name, region_name, 300)
 CreateOxidePotentialOnly(device_name, region_name)

--- a/testing/ptest2.py
+++ b/testing/ptest2.py
@@ -5,8 +5,9 @@
 ####
 #### package test for drift diffusion
 ####
-from devsim import *
-from devsim.python_packages.simple_physics import *
+from devsim import add_1d_contact, add_1d_mesh_line, add_1d_region, create_1d_mesh, create_device, finalize_mesh, get_contact_list, get_node_model_values, set_node_values, set_parameter, solve
+
+from devsim.python_packages.simple_physics import GetContactBiasName, PrintCurrents, SetSiliconParameters, CreateSiliconPotentialOnly, CreateSiliconPotentialOnlyContact, CreateSiliconDriftDiffusion, CreateSiliconDriftDiffusionAtContact
 
 device="MyDevice"
 region="MyRegion"

--- a/testing/pythonmesh1d.py
+++ b/testing/pythonmesh1d.py
@@ -1,5 +1,6 @@
 
-from devsim import *
+from devsim import add_gmsh_contact, add_gmsh_interface, add_gmsh_region, create_device, create_gmsh_mesh, finalize_mesh, get_contact_list, get_element_node_list, get_interface_list, get_node_model_values, get_region_list, write_devices
+
 import itertools
 
 print("coordinates")

--- a/testing/rundifftest.py
+++ b/testing/rundifftest.py
@@ -8,7 +8,6 @@
 import argparse
 import os
 import subprocess
-import difflib
 
 parser = argparse.ArgumentParser()
 

--- a/testing/sqlite2.py
+++ b/testing/sqlite2.py
@@ -14,7 +14,8 @@
 #set x [db1 eval {INSERT INTO t1 VALUES('global', 'm0', '9.10938188e-31', 'kg', 'Electron Mass')}];
 #set x [db1 eval {SELECT * FROM t1 ORDER BY material}]
 #puts $x
-from devsim import *
+from devsim import add_db_entry, close_db, create_db, get_db_entry, open_db, save_db
+
 create_db(filename="foodb")
 add_db_entry(material="global", parameter="q", value=1.60217646e-19, unit="coul", description="Electron Charge")
 add_db_entry(material="global", parameter="one", value=2, unit="", description="")

--- a/testing/sqlite3.py
+++ b/testing/sqlite3.py
@@ -2,7 +2,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from devsim import *
+from devsim import add_1d_contact, add_1d_mesh_line, add_1d_region, add_db_entry, create_1d_mesh, create_db, create_device, finalize_mesh, get_material, node_model, print_node_values, set_material
+
 #print region_info
 device ="d1"
 region ="r1"

--- a/testing/testfunc.py
+++ b/testing/testfunc.py
@@ -2,7 +2,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from devsim import *
+from devsim import add_1d_contact, add_1d_mesh_line, add_1d_region, create_1d_mesh, create_device, finalize_mesh, node_model, print_node_values, register_function, symdiff
+
 from math import cos
 from math import sin
 device = "MyDevice"

--- a/testing/testfunc_extended.py
+++ b/testing/testfunc_extended.py
@@ -4,4 +4,5 @@
 ###
 import devsim
 devsim.set_parameter(name="extended_model", value=True)
+
 import testfunc

--- a/testing/utf8_2.py
+++ b/testing/utf8_2.py
@@ -5,7 +5,8 @@
 
 ##Title: cap1.py
 ##Purpose: Simple example for 1D capacitor
-from devsim import *
+from devsim import add_1d_contact, add_1d_mesh_line, add_1d_region, contact_equation, create_1d_mesh, create_device, edge_from_node_model, edge_model, equation, finalize_mesh, get_contact_charge, get_parameter, node_model, node_solution, set_parameter, solve
+
 
 device_info = {'device' : 'MyDevice'}
 region_info = device_info


### PR DESCRIPTION
star imports clutter the namespace and make it difficult for automated tools to navigate the codebase. See [official Python documentation](https://docs.python.org/3/faq/programming.html#what-are-the-best-practices-for-using-import-in-a-module) and [PEP8 guide](https://peps.python.org/pep-0008/#imports).

I refactored all Python module/example/testing files to explicitly import functions instead of using star imports whenever possible. 

I have run all the files under testing/ and examples/, and they all execute without import errors.

In general this is a first step toward enforcing style guides to improve readability.