### PR TITLE
Proposal: Enforce Python formatting

### DIFF
--- a/.github/workflows/pre_commit.yml
+++ b/.github/workflows/pre_commit.yml
@@ -1,0 +1,26 @@
+name: Enforce formatting
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+      - name: Test pre-commit hooks
+        run: |
+          python -m pip install --upgrade pip
+          pip install pre-commit
+          pre-commit run -a

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,12 @@
+repos:
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    # Ruff version.
+    rev: v0.4.7
+    hooks:
+      # Run the linter.
+      - id: ruff
+        types_or: [ python ]
+        args: [ --fix ]
+      # Run the formatter.
+      - id: ruff-format

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,3 +20,24 @@ https://forum.devsim.org
 and let us know how you would like to help.
 
 Please see the [Testing](README.md#Testing) and [Related Projects](README.md#Related-Projects) section in [README.md](README.md) for additional places where help is needed.
+
+## Contributing on Github
+
+The DEVSIM source code is currently hosted on Github at https://github.com/devsim/devsim. We accept pull requests.
+
+Before contributing, you may want to explore the [Issues](https://github.com/devsim/devsim/issues) page to see if there is an issue you can help with. There is also active discussion on the [forum](https://forum.devsim.org).
+
+If you are ready to contribute, fork the repository, make your changes, and submit a pull request. We use [pre-commit hooks](https://pre-commit.com/) to enforce formatting and style. Please install pre-commit using:
+```
+pip install pre-commit # or use a relevant system package manager
+pre-commit install
+```
+The hooks (currently, only code formatting) will then run when you commit changes. You can also manually run the hooks using:
+```
+pre-commit run
+```
+When you make a pull request, the hooks will run server-side. The checks will fail if code is improperly formatted.
+
+## Licensing
+
+Note that we request all contributions to be licensed under the [Apache License Version 2.0, January 2004](https://apache.org/licenses/LICENSE-2.0). This is explained in the pull request template.

--- a/examples/bioapp1/bioapp1_2d.py
+++ b/examples/bioapp1/bioapp1_2d.py
@@ -2,48 +2,84 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import sys
+from devsim import (
+    add_gmsh_contact,
+    add_gmsh_interface,
+    add_gmsh_region,
+    create_device,
+    create_gmsh_mesh,
+    finalize_mesh,
+    node_model,
+    node_solution,
+    set_node_values,
+    set_parameter,
+    solve,
+    write_devices,
+)
+
 global device
 device = "disk"
 
-import sys
-from devsim import add_gmsh_contact, add_gmsh_interface, add_gmsh_region, create_device, create_gmsh_mesh, finalize_mesh, node_model, node_solution, set_node_values, set_parameter, solve, write_devices
-
-
 if len(sys.argv) != 2:
-    sys.stderr.write('must specify voltage')
+    sys.stderr.write("must specify voltage")
     sys.exit(1)
 
-Ve=float(sys.argv[1])
-#Ensure tcl is doing floating point math on the bias
-set_parameter(name="top_bias", value=Ve/2.0)
-set_parameter(name="bot_bias", value=-Ve/2.0)
+Ve = float(sys.argv[1])
+# Ensure tcl is doing floating point math on the bias
+set_parameter(name="top_bias", value=Ve / 2.0)
+set_parameter(name="bot_bias", value=-Ve / 2.0)
 
 
 create_gmsh_mesh(file="disk_2d.msh", mesh="disk")
-add_gmsh_region (mesh="disk", gmsh_name="solution", region="solution", material="ionic_solution")
-add_gmsh_region (mesh="disk", gmsh_name="dna", region="dna", material="dna")
-add_gmsh_region (mesh="disk", gmsh_name="dielectric", region="dielectric", material="dielectric")
-add_gmsh_contact(mesh="disk", gmsh_name="top", region="solution", name="top", material="metal")
-add_gmsh_contact(mesh="disk", gmsh_name="bot", region="solution", name="bot", material="metal")
-add_gmsh_interface(mesh="disk", gmsh_name="dielectric_solution", region0="dielectric", region1="solution", name="dielectric_solution")
-add_gmsh_interface(mesh="disk", gmsh_name="dna_solution",        region0="dna", region1="solution", name="dna_solution")
+add_gmsh_region(
+    mesh="disk", gmsh_name="solution", region="solution", material="ionic_solution"
+)
+add_gmsh_region(mesh="disk", gmsh_name="dna", region="dna", material="dna")
+add_gmsh_region(
+    mesh="disk", gmsh_name="dielectric", region="dielectric", material="dielectric"
+)
+add_gmsh_contact(
+    mesh="disk", gmsh_name="top", region="solution", name="top", material="metal"
+)
+add_gmsh_contact(
+    mesh="disk", gmsh_name="bot", region="solution", name="bot", material="metal"
+)
+add_gmsh_interface(
+    mesh="disk",
+    gmsh_name="dielectric_solution",
+    region0="dielectric",
+    region1="solution",
+    name="dielectric_solution",
+)
+add_gmsh_interface(
+    mesh="disk",
+    gmsh_name="dna_solution",
+    region0="dna",
+    region1="solution",
+    name="dna_solution",
+)
 finalize_mesh(mesh="disk")
 create_device(mesh="disk", device=device)
 
-import bioapp1_common
+import bioapp1_common  # noqa: F401, E402
 
 set_parameter(device="disk", region="dna", name="charge_density", value=0)
 solve(type="dc", relative_error=1e-7, absolute_error=1e11, maximum_iterations=100)
 for region in ("dna", "dielectric", "solution"):
-    node_solution   (device=device, region=region, name="Potential_zero")
-    set_node_values (device=device, region=region, name="Potential_zero", init_from="Potential")
+    node_solution(device=device, region=region, name="Potential_zero")
+    set_node_values(
+        device=device, region=region, name="Potential_zero", init_from="Potential"
+    )
 
 set_parameter(device="disk", region="dna", name="charge_density", value=2e21)
 solve(type="dc", relative_error=1e-7, absolute_error=1e11, maximum_iterations=100)
 for region in ("dna", "dielectric", "solution"):
-    node_model(device=device, region=region, name="LogDeltaPotential",
-               equation="log(abs(Potential-Potential_zero) + 1e-10)/log(10)")
+    node_model(
+        device=device,
+        region=region,
+        name="LogDeltaPotential",
+        equation="log(abs(Potential-Potential_zero) + 1e-10)/log(10)",
+    )
 
-write_devices(file="bioapp1_2d_{0}.dat".format(Ve),  type="tecplot")
-
-
+write_devices(file="bioapp1_2d_{0}.dat".format(Ve), type="tecplot")

--- a/examples/bioapp1/bioapp1_3d.py
+++ b/examples/bioapp1/bioapp1_3d.py
@@ -2,49 +2,84 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import sys
+from devsim import (
+    add_gmsh_contact,
+    add_gmsh_interface,
+    add_gmsh_region,
+    create_device,
+    create_gmsh_mesh,
+    finalize_mesh,
+    node_model,
+    node_solution,
+    set_node_values,
+    set_parameter,
+    solve,
+    write_devices,
+)
+
 global device
 device = "disk"
 
-import sys
-from devsim import add_gmsh_contact, add_gmsh_interface, add_gmsh_region, create_device, create_gmsh_mesh, finalize_mesh, node_model, node_solution, set_node_values, set_parameter, solve, write_devices
-
-
 if len(sys.argv) != 2:
-    sys.stderr.write('must specify voltage')
+    sys.stderr.write("must specify voltage")
     sys.exit(1)
 
-Ve=float(sys.argv[1])
-#Ensure tcl is doing floating point math on the bias
-set_parameter(name="top_bias", value=Ve/2.0)
-set_parameter(name="bot_bias", value=-Ve/2.0)
+Ve = float(sys.argv[1])
+# Ensure tcl is doing floating point math on the bias
+set_parameter(name="top_bias", value=Ve / 2.0)
+set_parameter(name="bot_bias", value=-Ve / 2.0)
 
 
 create_gmsh_mesh(file="disk_3d.msh", mesh="disk")
-add_gmsh_region (mesh="disk", gmsh_name="solution", region="solution", material="ionic_solution")
-add_gmsh_region (mesh="disk", gmsh_name="dna", region="dna", material="dna")
-add_gmsh_region (mesh="disk", gmsh_name="dielectric", region="dielectric", material="dielectric")
-add_gmsh_contact(mesh="disk", gmsh_name="top", region="solution", name="top", material="metal")
-add_gmsh_contact(mesh="disk", gmsh_name="bot", region="solution", name="bot", material="metal")
-add_gmsh_interface(mesh="disk", gmsh_name="dielectric_solution", region0="dielectric", region1="solution", name="dielectric_solution")
-add_gmsh_interface(mesh="disk", gmsh_name="dna_solution",        region0="dna", region1="solution", name="dna_solution")
+add_gmsh_region(
+    mesh="disk", gmsh_name="solution", region="solution", material="ionic_solution"
+)
+add_gmsh_region(mesh="disk", gmsh_name="dna", region="dna", material="dna")
+add_gmsh_region(
+    mesh="disk", gmsh_name="dielectric", region="dielectric", material="dielectric"
+)
+add_gmsh_contact(
+    mesh="disk", gmsh_name="top", region="solution", name="top", material="metal"
+)
+add_gmsh_contact(
+    mesh="disk", gmsh_name="bot", region="solution", name="bot", material="metal"
+)
+add_gmsh_interface(
+    mesh="disk",
+    gmsh_name="dielectric_solution",
+    region0="dielectric",
+    region1="solution",
+    name="dielectric_solution",
+)
+add_gmsh_interface(
+    mesh="disk",
+    gmsh_name="dna_solution",
+    region0="dna",
+    region1="solution",
+    name="dna_solution",
+)
 finalize_mesh(mesh="disk")
 create_device(mesh="disk", device=device)
 
-import bioapp1_common
-# from bioapp1_common import *
+import bioapp1_common  # noqa: F401, E402
 
 set_parameter(device="disk", region="dna", name="charge_density", value=0)
 solve(type="dc", relative_error=1e-7, absolute_error=1e11, maximum_iterations=100)
 for region in ("dna", "dielectric", "solution"):
-    node_solution   (device=device, region=region, name="Potential_zero")
-    set_node_values (device=device, region=region, name="Potential_zero", init_from="Potential")
+    node_solution(device=device, region=region, name="Potential_zero")
+    set_node_values(
+        device=device, region=region, name="Potential_zero", init_from="Potential"
+    )
 
 set_parameter(device="disk", region="dna", name="charge_density", value=2e21)
 solve(type="dc", relative_error=1e-7, absolute_error=1e11, maximum_iterations=100)
 for region in ("dna", "dielectric", "solution"):
-    node_model(device=device, region=region, name="LogDeltaPotential",
-               equation="log(abs(Potential-Potential_zero) + 1e-10)/log(10)")
+    node_model(
+        device=device,
+        region=region,
+        name="LogDeltaPotential",
+        equation="log(abs(Potential-Potential_zero) + 1e-10)/log(10)",
+    )
 
-write_devices(file="bioapp1_3d_{0}.dat".format(Ve),  type="tecplot")
-
-
+write_devices(file="bioapp1_3d_{0}.dat".format(Ve), type="tecplot")

--- a/examples/bioapp1/bioapp1_common.py
+++ b/examples/bioapp1/bioapp1_common.py
@@ -2,26 +2,81 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from devsim import add_db_entry, contact_equation, contact_node_model, create_db, cylindrical_edge_couple, cylindrical_node_volume, edge_from_node_model, edge_model, element_from_edge_model, equation, get_dimension, get_node_model_values, interface_equation, interface_model, node_model, node_solution, set_node_values, set_parameter
+from devsim import (
+    add_db_entry,
+    contact_equation,
+    contact_node_model,
+    create_db,
+    cylindrical_edge_couple,
+    cylindrical_node_volume,
+    edge_from_node_model,
+    edge_model,
+    element_from_edge_model,
+    equation,
+    get_dimension,
+    get_node_model_values,
+    interface_equation,
+    interface_model,
+    node_model,
+    node_solution,
+    set_node_values,
+    set_parameter,
+)
 
 #### molarity 0.001 mole / Liter * 1 L / (1e3 cm^3) * 6.02e23 / mole = 6.02e17 /cm^3
 set_parameter(device="disk", region="solution", name="n_bound", value=6.02e17)
 #### 2q/nm^3 -->  2/nm^3 * (1 nm^3/(1e-7 cm)^3)
-#set_parameter device="disk", region="dna",        name="charge_density", value=0,
-set_parameter(device="disk", region="dna",        name="charge_density", value=2e21)
+# set_parameter device="disk", region="dna",        name="charge_density", value=0,
+set_parameter(device="disk", region="dna", name="charge_density", value=2e21)
 set_parameter(device="disk", region="dielectric", name="charge_density", value=0)
 
-dimension=get_dimension(device="disk")
+dimension = get_dimension(device="disk")
 
 create_db(filename="materialdb_{0}d".format(dimension))
-add_db_entry(material="global", parameter="q", value=1.6e-19, unit="coul", description="Charge of an electron")
-add_db_entry(material="ionic_solution", parameter="mu_c", value=7.62e-4, unit="cm^2/(V*sec)", description="mobility of cations (K+)")
-add_db_entry(material="ionic_solution", parameter="mu_a", value=7.98e-4, unit="cm^2/(V*sec)", description="mobility of anions (Cl-)")
-add_db_entry(material="ionic_solution", parameter="Permittivity", value=80 * 8.85e-14, unit="F/cm", description="")
-add_db_entry(material="dielectric",     parameter="Permittivity", value=3  * 8.85e-14, unit="F/cm", description="")
-add_db_entry(material="dna",            parameter="Permittivity", value=4  * 8.85e-14, unit="F/cm", description="")
+add_db_entry(
+    material="global",
+    parameter="q",
+    value=1.6e-19,
+    unit="coul",
+    description="Charge of an electron",
+)
+add_db_entry(
+    material="ionic_solution",
+    parameter="mu_c",
+    value=7.62e-4,
+    unit="cm^2/(V*sec)",
+    description="mobility of cations (K+)",
+)
+add_db_entry(
+    material="ionic_solution",
+    parameter="mu_a",
+    value=7.98e-4,
+    unit="cm^2/(V*sec)",
+    description="mobility of anions (Cl-)",
+)
+add_db_entry(
+    material="ionic_solution",
+    parameter="Permittivity",
+    value=80 * 8.85e-14,
+    unit="F/cm",
+    description="",
+)
+add_db_entry(
+    material="dielectric",
+    parameter="Permittivity",
+    value=3 * 8.85e-14,
+    unit="F/cm",
+    description="",
+)
+add_db_entry(
+    material="dna",
+    parameter="Permittivity",
+    value=4 * 8.85e-14,
+    unit="F/cm",
+    description="",
+)
 
-set_parameter(device="disk", region="solution", name="V_t",   value=0.0238)
+set_parameter(device="disk", region="solution", name="V_t", value=0.0238)
 
 for region in ("dna", "dielectric", "solution"):
     node_solution(device="disk", region=region, name="Potential")
@@ -29,123 +84,300 @@ for region in ("dna", "dielectric", "solution"):
 
     if dimension == 2:
         set_parameter(device="disk", name="raxis_variable", value="x")
-        set_parameter(device="disk", name="raxis_zero",     value=0)
+        set_parameter(device="disk", name="raxis_zero", value=0)
         cylindrical_node_volume(device="disk", region=region)
         cylindrical_edge_couple(device="disk", region=region)
 
-        set_parameter(name="node_volume_model",          value="CylindricalNodeVolume")
-        set_parameter(name="edge_couple_model",          value="CylindricalEdgeCouple")
-        set_parameter(name="element_edge_couple_model",  value="ElementCylindricalEdgeCouple")
-        set_parameter(name="element_node0_volume_model", value="ElementCylindricalNodeVolume@en0")
-        set_parameter(name="element_node1_volume_model", value="ElementCylindricalNodeVolume@en1")
+        set_parameter(name="node_volume_model", value="CylindricalNodeVolume")
+        set_parameter(name="edge_couple_model", value="CylindricalEdgeCouple")
+        set_parameter(
+            name="element_edge_couple_model", value="ElementCylindricalEdgeCouple"
+        )
+        set_parameter(
+            name="element_node0_volume_model", value="ElementCylindricalNodeVolume@en0"
+        )
+        set_parameter(
+            name="element_node1_volume_model", value="ElementCylindricalNodeVolume@en1"
+        )
 
-        x=sum(get_node_model_values(device="disk", region=region, name="CylindricalNodeVolume"))
-        y=sum(get_node_model_values(device="disk", region=region, name="NodeVolume"))
+        x = sum(
+            get_node_model_values(
+                device="disk", region=region, name="CylindricalNodeVolume"
+            )
+        )
+        y = sum(get_node_model_values(device="disk", region=region, name="NodeVolume"))
         print("Volume {0} {1} {2}".format(region, x, y))
     else:
-        y=sum(get_node_model_values(device="disk", region=region, name="NodeVolume"))
+        y = sum(get_node_model_values(device="disk", region=region, name="NodeVolume"))
         print("Volume {0} {1}".format(region, y))
 
     # Electric Field Edge Model
-    edge_model(device="disk", region=region, name="EField",
-               equation="(Potential@n0 - Potential@n1)*EdgeInverseLength")
+    edge_model(
+        device="disk",
+        region=region,
+        name="EField",
+        equation="(Potential@n0 - Potential@n1)*EdgeInverseLength",
+    )
 
-    edge_model(device="disk", region=region, name="EField:Potential@n0",
-               equation="EdgeInverseLength",)
+    edge_model(
+        device="disk",
+        region=region,
+        name="EField:Potential@n0",
+        equation="EdgeInverseLength",
+    )
 
-    edge_model(device="disk", region=region, name="EField:Potential@n1",
-               equation="-EdgeInverseLength")
+    edge_model(
+        device="disk",
+        region=region,
+        name="EField:Potential@n1",
+        equation="-EdgeInverseLength",
+    )
 
-    edge_model(device="disk", region=region, name="DField",              equation="Permittivity*EField")
-    edge_model(device="disk", region=region, name="DField:Potential@n0", equation="Permittivity*EField:Potential@n0")
-    edge_model(device="disk", region=region, name="DField:Potential@n1", equation="Permittivity*EField:Potential@n1")
+    edge_model(
+        device="disk", region=region, name="DField", equation="Permittivity*EField"
+    )
+    edge_model(
+        device="disk",
+        region=region,
+        name="DField:Potential@n0",
+        equation="Permittivity*EField:Potential@n0",
+    )
+    edge_model(
+        device="disk",
+        region=region,
+        name="DField:Potential@n1",
+        equation="Permittivity*EField:Potential@n1",
+    )
 
-#create anions and cations solution variable in solution (positive only applied in equation)
+# create anions and cations solution variable in solution (positive only applied in equation)
 node_solution(device="disk", region="solution", name="cations")
 edge_from_node_model(device="disk", region="solution", node_model="cations")
 node_solution(device="disk", region="solution", name="anions")
 edge_from_node_model(device="disk", region="solution", node_model="anions")
 node_model(device="disk", region="solution", name="small_value", equation="n_bound")
-set_node_values(device="disk", region="solution", name="cations", init_from="small_value")
-set_node_values(device="disk", region="solution", name="anions", init_from="small_value")
+set_node_values(
+    device="disk", region="solution", name="cations", init_from="small_value"
+)
+set_node_values(
+    device="disk", region="solution", name="anions", init_from="small_value"
+)
 
-#create Poisson equation in each region
-#sign is negative since poisson equation all on lhs
-node_model(device="disk", region="solution", name="NetCharge",        equation="q*(anions - cations)")
-node_model(device="disk", region="solution", name="NetCharge:anions",  equation="q")
+# create Poisson equation in each region
+# sign is negative since poisson equation all on lhs
+node_model(
+    device="disk", region="solution", name="NetCharge", equation="q*(anions - cations)"
+)
+node_model(device="disk", region="solution", name="NetCharge:anions", equation="q")
 node_model(device="disk", region="solution", name="NetCharge:cations", equation="-q")
 
-equation(device="disk", region="solution", name="PotentialEquation", variable_name="Potential",
-         node_model="NetCharge", edge_model="DField", variable_update="default")
+equation(
+    device="disk",
+    region="solution",
+    name="PotentialEquation",
+    variable_name="Potential",
+    node_model="NetCharge",
+    edge_model="DField",
+    variable_update="default",
+)
 
 
 for region in ("dna", "dielectric"):
-    node_model(device="disk", region=region, name="NetCharge", equation="-q*charge_density")
-    equation(device="disk", region=region, name="PotentialEquation", variable_name="Potential",
-             node_model="NetCharge", edge_model="DField", variable_update="default")
+    node_model(
+        device="disk", region=region, name="NetCharge", equation="-q*charge_density"
+    )
+    equation(
+        device="disk",
+        region=region,
+        name="PotentialEquation",
+        variable_name="Potential",
+        node_model="NetCharge",
+        edge_model="DField",
+        variable_update="default",
+    )
 
-#create fluxes in solution
+# create fluxes in solution
 # This is complicated, but the Bernoulli functions are a representation of Sharfetter Gummel
-vdiffstr="(Potential@n0 - Potential@n1)/V_t"
+vdiffstr = "(Potential@n0 - Potential@n1)/V_t"
 edge_model(device="disk", region="solution", name="vdiff", equation=vdiffstr)
 # #assuming that Potential is based on a solution, and not a model
-edge_model(device="disk", region="solution", name="vdiff:Potential@n0", equation="V_t^(-1)")
-edge_model(device="disk", region="solution", name="vdiff:Potential@n1", equation="-V_t^(-1)")
+edge_model(
+    device="disk", region="solution", name="vdiff:Potential@n0", equation="V_t^(-1)"
+)
+edge_model(
+    device="disk", region="solution", name="vdiff:Potential@n1", equation="-V_t^(-1)"
+)
 #
-edge_model(device="disk", region="solution", name="Bern01",              equation="B(vdiff)")
-edge_model(device="disk", region="solution", name="Bern01:Potential@n0", equation="dBdx(vdiff) * vdiff:Potential@n0")
-edge_model(device="disk", region="solution", name="Bern01:Potential@n1", equation="-Bern01:Potential@n0")
+edge_model(device="disk", region="solution", name="Bern01", equation="B(vdiff)")
+edge_model(
+    device="disk",
+    region="solution",
+    name="Bern01:Potential@n0",
+    equation="dBdx(vdiff) * vdiff:Potential@n0",
+)
+edge_model(
+    device="disk",
+    region="solution",
+    name="Bern01:Potential@n1",
+    equation="-Bern01:Potential@n0",
+)
 # #identity of Bernoulli functions
-edge_model(device="disk", region="solution", name="Bern10",              equation="Bern01 + vdiff")
-edge_model(device="disk", region="solution", name="Bern10:Potential@n0", equation="Bern01:Potential@n0 + vdiff:Potential@n0")
-edge_model(device="disk", region="solution", name="Bern10:Potential@n1", equation="Bern01:Potential@n1 + vdiff:Potential@n1")
+edge_model(device="disk", region="solution", name="Bern10", equation="Bern01 + vdiff")
+edge_model(
+    device="disk",
+    region="solution",
+    name="Bern10:Potential@n0",
+    equation="Bern01:Potential@n0 + vdiff:Potential@n0",
+)
+edge_model(
+    device="disk",
+    region="solution",
+    name="Bern10:Potential@n1",
+    equation="Bern01:Potential@n1 + vdiff:Potential@n1",
+)
 
-Ja=" q*mu_a*EdgeInverseLength*V_t*(anions@n1*Bern10  - anions@n0*Bern01)"
-edge_model(device="disk", region="solution", name="AnionFlux", equation="{0}".format(Ja))
+Ja = " q*mu_a*EdgeInverseLength*V_t*(anions@n1*Bern10  - anions@n0*Bern01)"
+edge_model(
+    device="disk", region="solution", name="AnionFlux", equation="{0}".format(Ja)
+)
 
-Jc="-q*mu_c*EdgeInverseLength*V_t*(cations@n1*Bern01 - cations@n0*Bern10)"
-edge_model(device="disk", region="solution", name="CationFlux", equation="{0}".format(Jc))
+Jc = "-q*mu_c*EdgeInverseLength*V_t*(cations@n1*Bern01 - cations@n0*Bern10)"
+edge_model(
+    device="disk", region="solution", name="CationFlux", equation="{0}".format(Jc)
+)
 
-#derivatives w.r.t. the solution variables
-for v in ("Potential@n0", "Potential@n1", "anions@n0", "anions@n1", "cations@n0", "cations@n1"):
-    edge_model(device="disk", region="solution", name="AnionFlux:{0}".format(v),  equation="simplify(diff({0},{1}))".format(Ja, v))
-    edge_model(device="disk", region="solution", name="CationFlux:{0}".format(v), equation="simplify(diff({0},{1}))".format(Jc, v))
+# derivatives w.r.t. the solution variables
+for v in (
+    "Potential@n0",
+    "Potential@n1",
+    "anions@n0",
+    "anions@n1",
+    "cations@n0",
+    "cations@n1",
+):
+    edge_model(
+        device="disk",
+        region="solution",
+        name="AnionFlux:{0}".format(v),
+        equation="simplify(diff({0},{1}))".format(Ja, v),
+    )
+    edge_model(
+        device="disk",
+        region="solution",
+        name="CationFlux:{0}".format(v),
+        equation="simplify(diff({0},{1}))".format(Jc, v),
+    )
 
-#create continuity equations in solution
-equation(device="disk", region="solution", name="AnionContinuityEquation", variable_name="anions",
-         edge_model="AnionFlux", variable_update="positive")
+# create continuity equations in solution
+equation(
+    device="disk",
+    region="solution",
+    name="AnionContinuityEquation",
+    variable_name="anions",
+    edge_model="AnionFlux",
+    variable_update="positive",
+)
 
-equation(device="disk", region="solution", name="CationContinuityEquation", variable_name="cations", \
-         edge_model="CationFlux", variable_update="positive")
+equation(
+    device="disk",
+    region="solution",
+    name="CationContinuityEquation",
+    variable_name="cations",
+    edge_model="CationFlux",
+    variable_update="positive",
+)
 
-#create n0, and potential boundary condition at contact
+# create n0, and potential boundary condition at contact
 for contact in ("top", "bot"):
-    node_model(device="disk", region="solution", name="{0}_potential".format(contact), equation="Potential - {0}_bias".format(contact))
-    node_model(device="disk", region="solution", name="{0}_potential:Potential".format(contact), equation="1")
+    node_model(
+        device="disk",
+        region="solution",
+        name="{0}_potential".format(contact),
+        equation="Potential - {0}_bias".format(contact),
+    )
+    node_model(
+        device="disk",
+        region="solution",
+        name="{0}_potential:Potential".format(contact),
+        equation="1",
+    )
 
-    contact_equation(device="disk", contact=contact, name="PotentialEquation",
-                     node_model="{0}_potential".format(contact), edge_charge_model="DField")
+    contact_equation(
+        device="disk",
+        contact=contact,
+        name="PotentialEquation",
+        node_model="{0}_potential".format(contact),
+        edge_charge_model="DField",
+    )
 
-    contact_node_model(device="disk", contact=contact, name="{0}_anion".format(contact), equation="anions - n_bound")
-    contact_node_model(device="disk", contact=contact, name="{0}_anion:anions".format(contact), equation="1")
-    contact_equation(device="disk", contact=contact, name="AnionContinuityEquation", node_model="{0}_anion".format(contact))
+    contact_node_model(
+        device="disk",
+        contact=contact,
+        name="{0}_anion".format(contact),
+        equation="anions - n_bound",
+    )
+    contact_node_model(
+        device="disk",
+        contact=contact,
+        name="{0}_anion:anions".format(contact),
+        equation="1",
+    )
+    contact_equation(
+        device="disk",
+        contact=contact,
+        name="AnionContinuityEquation",
+        node_model="{0}_anion".format(contact),
+    )
 
-    contact_node_model(device="disk", contact=contact, name="{0}_cation".format(contact), equation="cations - n_bound")
-    contact_node_model(device="disk", contact=contact, name="{0}_cation:cations".format(contact), equation="1")
-    contact_equation(device="disk", contact=contact, name="CationContinuityEquation", node_model="{0}_cation".format(contact))
+    contact_node_model(
+        device="disk",
+        contact=contact,
+        name="{0}_cation".format(contact),
+        equation="cations - n_bound",
+    )
+    contact_node_model(
+        device="disk",
+        contact=contact,
+        name="{0}_cation:cations".format(contact),
+        equation="1",
+    )
+    contact_equation(
+        device="disk",
+        contact=contact,
+        name="CationContinuityEquation",
+        node_model="{0}_cation".format(contact),
+    )
 
 
-#create potential continuity at interfaces
+# create potential continuity at interfaces
 for interface in ("dna_solution", "dielectric_solution"):
-    interface_model(device="disk", interface=interface, name="continuousPotential", equation="Potential@r0-Potential@r1")
-    interface_model(device="disk", interface=interface, name="continuousPotential:Potential@r0", equation="1")
-    interface_model(device="disk", interface=interface, name="continuousPotential:Potential@r1", equation="-1")
-    interface_equation(device="disk", interface=interface, name="PotentialEquation", interface_model="continuousPotential", type="continuous")
+    interface_model(
+        device="disk",
+        interface=interface,
+        name="continuousPotential",
+        equation="Potential@r0-Potential@r1",
+    )
+    interface_model(
+        device="disk",
+        interface=interface,
+        name="continuousPotential:Potential@r0",
+        equation="1",
+    )
+    interface_model(
+        device="disk",
+        interface=interface,
+        name="continuousPotential:Potential@r1",
+        equation="-1",
+    )
+    interface_equation(
+        device="disk",
+        interface=interface,
+        name="PotentialEquation",
+        interface_model="continuousPotential",
+        type="continuous",
+    )
 
 # For visualization
 for region in ("dna", "dielectric", "solution"):
-    element_from_edge_model(edge_model="EField",     device="disk", region=region)
-element_from_edge_model(edge_model="AnionFlux",  device="disk", region="solution")
+    element_from_edge_model(edge_model="EField", device="disk", region=region)
+element_from_edge_model(edge_model="AnionFlux", device="disk", region="solution")
 element_from_edge_model(edge_model="CationFlux", device="disk", region="solution")
-
-

--- a/examples/capacitance/cap1d.py
+++ b/examples/capacitance/cap1d.py
@@ -2,27 +2,45 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from devsim import add_1d_contact, add_1d_mesh_line, add_1d_region, contact_equation, contact_node_model, create_1d_mesh, create_device, edge_from_node_model, edge_model, equation, finalize_mesh, get_contact_charge, node_solution, set_parameter, solve
+from devsim import (
+    add_1d_contact,
+    add_1d_mesh_line,
+    add_1d_region,
+    contact_equation,
+    contact_node_model,
+    create_1d_mesh,
+    create_device,
+    edge_from_node_model,
+    edge_model,
+    equation,
+    finalize_mesh,
+    get_contact_charge,
+    node_solution,
+    set_parameter,
+    solve,
+)
 
-device="MyDevice"
-region="MyRegion"
+device = "MyDevice"
+region = "MyRegion"
 
 ###
 ### Create a 1D mesh
 ###
-create_1d_mesh (mesh="mesh1")
-add_1d_mesh_line (mesh="mesh1", pos=0.0, ps=0.1, tag="contact1")
-add_1d_mesh_line (mesh="mesh1", pos=1.0, ps=0.1, tag="contact2")
-add_1d_contact   (mesh="mesh1", name="contact1", tag="contact1", material="metal")
-add_1d_contact   (mesh="mesh1", name="contact2", tag="contact2", material="metal")
-add_1d_region    (mesh="mesh1", material="Si", region=region, tag1="contact1", tag2="contact2")
-finalize_mesh (mesh="mesh1")
-create_device (mesh="mesh1", device=device)
+create_1d_mesh(mesh="mesh1")
+add_1d_mesh_line(mesh="mesh1", pos=0.0, ps=0.1, tag="contact1")
+add_1d_mesh_line(mesh="mesh1", pos=1.0, ps=0.1, tag="contact2")
+add_1d_contact(mesh="mesh1", name="contact1", tag="contact1", material="metal")
+add_1d_contact(mesh="mesh1", name="contact2", tag="contact2", material="metal")
+add_1d_region(
+    mesh="mesh1", material="Si", region=region, tag1="contact1", tag2="contact2"
+)
+finalize_mesh(mesh="mesh1")
+create_device(mesh="mesh1", device=device)
 
 ###
 ### Set parameters on the region
 ###
-set_parameter(device=device, region=region, name="Permittivity", value=3.9*8.85e-14)
+set_parameter(device=device, region=region, name="Permittivity", value=3.9 * 8.85e-14)
 
 ###
 ### Create the Potential solution variable
@@ -38,46 +56,80 @@ edge_from_node_model(device=device, region=region, node_model="Potential")
 ### Electric field on each edge, as well as its derivatives with respect to
 ### the potential at each node
 ###
-edge_model(device=device, region=region, name="ElectricField",
-           equation="(Potential@n0 - Potential@n1)*EdgeInverseLength")
+edge_model(
+    device=device,
+    region=region,
+    name="ElectricField",
+    equation="(Potential@n0 - Potential@n1)*EdgeInverseLength",
+)
 
-edge_model(device=device, region=region, name="ElectricField:Potential@n0",
-           equation="EdgeInverseLength")
+edge_model(
+    device=device,
+    region=region,
+    name="ElectricField:Potential@n0",
+    equation="EdgeInverseLength",
+)
 
-edge_model(device=device, region=region, name="ElectricField:Potential@n1",
-           equation="-EdgeInverseLength")
+edge_model(
+    device=device,
+    region=region,
+    name="ElectricField:Potential@n1",
+    equation="-EdgeInverseLength",
+)
 
 ###
 ### Model the D Field
 ###
-edge_model(device=device, region=region, name="DField",
-           equation="Permittivity*ElectricField")
+edge_model(
+    device=device, region=region, name="DField", equation="Permittivity*ElectricField"
+)
 
-edge_model(device=device, region=region, name="DField:Potential@n0",
-           equation="diff(Permittivity*ElectricField, Potential@n0)")
+edge_model(
+    device=device,
+    region=region,
+    name="DField:Potential@n0",
+    equation="diff(Permittivity*ElectricField, Potential@n0)",
+)
 
-edge_model(device=device, region=region, name="DField:Potential@n1",
-           equation="-DField:Potential@n0")
+edge_model(
+    device=device,
+    region=region,
+    name="DField:Potential@n1",
+    equation="-DField:Potential@n0",
+)
 
 ###
 ### Create the bulk equation
 ###
-equation(device=device, region=region, name="PotentialEquation", variable_name="Potential",
-         edge_model="DField", variable_update="default")
+equation(
+    device=device,
+    region=region,
+    name="PotentialEquation",
+    variable_name="Potential",
+    edge_model="DField",
+    variable_update="default",
+)
 
 
 ###
 ### Contact models and equations
 ###
 for c in ("contact1", "contact2"):
-    contact_node_model(device=device, contact=c, name="%s_bc" % c,
-                       equation="Potential - %s_bias" % c)
+    contact_node_model(
+        device=device, contact=c, name="%s_bc" % c, equation="Potential - %s_bias" % c
+    )
 
-    contact_node_model(device=device, contact=c, name="%s_bc:Potential" % c,
-                       equation="1")
+    contact_node_model(
+        device=device, contact=c, name="%s_bc:Potential" % c, equation="1"
+    )
 
-    contact_equation(device=device, contact=c, name="PotentialEquation",
-                     node_model="%s_bc" % c, edge_charge_model="DField")
+    contact_equation(
+        device=device,
+        contact=c,
+        name="PotentialEquation",
+        node_model="%s_bc" % c,
+        edge_charge_model="DField",
+    )
 
 ###
 ### Set the contact
@@ -94,5 +146,10 @@ solve(type="dc", absolute_error=1.0, relative_error=1e-10, maximum_iterations=30
 ### Print the charge on the contacts
 ###
 for c in ("contact1", "contact2"):
-    print ("contact: %s charge: %1.5e" % (c, get_contact_charge(device=device, contact=c, equation="PotentialEquation")))
-
+    print(
+        "contact: %s charge: %1.5e"
+        % (
+            c,
+            get_contact_charge(device=device, contact=c, equation="PotentialEquation"),
+        )
+    )

--- a/examples/capacitance/cap2d.py
+++ b/examples/capacitance/cap2d.py
@@ -2,59 +2,83 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from devsim import add_2d_contact, add_2d_mesh_line, add_2d_region, contact_equation, contact_node_model, create_2d_mesh, create_device, edge_from_node_model, edge_model, element_from_edge_model, equation, finalize_mesh, get_contact_charge, node_model, node_solution, set_parameter, solve, write_devices
+from devsim import (
+    add_2d_contact,
+    add_2d_mesh_line,
+    add_2d_region,
+    contact_equation,
+    contact_node_model,
+    create_2d_mesh,
+    create_device,
+    edge_from_node_model,
+    edge_model,
+    element_from_edge_model,
+    equation,
+    finalize_mesh,
+    get_contact_charge,
+    node_model,
+    node_solution,
+    set_parameter,
+    solve,
+    write_devices,
+)
 
-device="MyDevice"
-region="MyRegion"
+device = "MyDevice"
+region = "MyRegion"
 
-xmin=-25
-x1  =-24.975
-x2  =-2
-x3  =2
-x4  =24.975
-xmax=25.0
+xmin = -25
+x1 = -24.975
+x2 = -2
+x3 = 2
+x4 = 24.975
+xmax = 25.0
 
-ymin=0.0
-y1  =0.1
-y2  =0.2
-y3  =0.8
-y4  =0.9
-ymax=50.0
+ymin = 0.0
+y1 = 0.1
+y2 = 0.2
+y3 = 0.8
+y4 = 0.9
+ymax = 50.0
 
 create_2d_mesh(mesh=device)
 add_2d_mesh_line(mesh=device, dir="y", pos=ymin, ps=0.1)
-add_2d_mesh_line(mesh=device, dir="y", pos=y1  , ps=0.1)
-add_2d_mesh_line(mesh=device, dir="y", pos=y2  , ps=0.1)
-add_2d_mesh_line(mesh=device, dir="y", pos=y3  , ps=0.1)
-add_2d_mesh_line(mesh=device, dir="y", pos=y4  , ps=0.1)
+add_2d_mesh_line(mesh=device, dir="y", pos=y1, ps=0.1)
+add_2d_mesh_line(mesh=device, dir="y", pos=y2, ps=0.1)
+add_2d_mesh_line(mesh=device, dir="y", pos=y3, ps=0.1)
+add_2d_mesh_line(mesh=device, dir="y", pos=y4, ps=0.1)
 add_2d_mesh_line(mesh=device, dir="y", pos=ymax, ps=5.0)
 
-device=device
-region="air"
+device = device
+region = "air"
 
 add_2d_mesh_line(mesh=device, dir="x", pos=xmin, ps=5)
-add_2d_mesh_line(mesh=device, dir="x", pos=x1  , ps=2)
-add_2d_mesh_line(mesh=device, dir="x", pos=x2  , ps=0.05)
-add_2d_mesh_line(mesh=device, dir="x", pos=x3  , ps=0.05)
-add_2d_mesh_line(mesh=device, dir="x", pos=x4  , ps=2)
+add_2d_mesh_line(mesh=device, dir="x", pos=x1, ps=2)
+add_2d_mesh_line(mesh=device, dir="x", pos=x2, ps=0.05)
+add_2d_mesh_line(mesh=device, dir="x", pos=x3, ps=0.05)
+add_2d_mesh_line(mesh=device, dir="x", pos=x4, ps=2)
 add_2d_mesh_line(mesh=device, dir="x", pos=xmax, ps=5)
 
-add_2d_region(mesh=device, material="gas"  , region="air", yl=ymin, yh=ymax, xl=xmin, xh=xmax)
-add_2d_region(mesh=device, material="metal", region="m1" , yl=y1  , yh=y2  , xl=x1  , xh=x4)
-add_2d_region(mesh=device, material="metal", region="m2" , yl=y3  , yh=y4  , xl=x2  , xh=x3)
+add_2d_region(
+    mesh=device, material="gas", region="air", yl=ymin, yh=ymax, xl=xmin, xh=xmax
+)
+add_2d_region(mesh=device, material="metal", region="m1", yl=y1, yh=y2, xl=x1, xh=x4)
+add_2d_region(mesh=device, material="metal", region="m2", yl=y3, yh=y4, xl=x2, xh=x3)
 
 # must be air since contacts don't have any equations
-add_2d_contact(mesh=device, name="bot", region="air", yl=y1, yh=y2, xl=x1, xh=x4, material="metal")
-add_2d_contact(mesh=device, name="top", region="air", yl=y3, yh=y4, xl=x2, xh=x3, material="metal")
+add_2d_contact(
+    mesh=device, name="bot", region="air", yl=y1, yh=y2, xl=x1, xh=x4, material="metal"
+)
+add_2d_contact(
+    mesh=device, name="top", region="air", yl=y3, yh=y4, xl=x2, xh=x3, material="metal"
+)
 finalize_mesh(mesh=device)
 create_device(mesh=device, device=device)
-
 
 
 ###
 ### Set parameters on the region
 ###
-set_parameter(device=device, region=region, name="Permittivity", value=3.9*8.85e-14)
+set_parameter(device=device, region=region, name="Permittivity", value=3.9 * 8.85e-14)
 
 ###
 ### Create the Potential solution variable
@@ -70,46 +94,80 @@ edge_from_node_model(device=device, region=region, node_model="Potential")
 ### Electric field on each edge, as well as its derivatives with respect to
 ### the potential at each node
 ###
-edge_model(device=device, region=region, name="ElectricField",
-           equation="(Potential@n0 - Potential@n1)*EdgeInverseLength")
+edge_model(
+    device=device,
+    region=region,
+    name="ElectricField",
+    equation="(Potential@n0 - Potential@n1)*EdgeInverseLength",
+)
 
-edge_model(device=device, region=region, name="ElectricField:Potential@n0",
-           equation="EdgeInverseLength")
+edge_model(
+    device=device,
+    region=region,
+    name="ElectricField:Potential@n0",
+    equation="EdgeInverseLength",
+)
 
-edge_model(device=device, region=region, name="ElectricField:Potential@n1",
-           equation="-EdgeInverseLength")
+edge_model(
+    device=device,
+    region=region,
+    name="ElectricField:Potential@n1",
+    equation="-EdgeInverseLength",
+)
 
 ###
 ### Model the D Field
 ###
-edge_model(device=device, region=region, name="DField",
-           equation="Permittivity*ElectricField")
+edge_model(
+    device=device, region=region, name="DField", equation="Permittivity*ElectricField"
+)
 
-edge_model(device=device, region=region, name="DField:Potential@n0",
-           equation="diff(Permittivity*ElectricField, Potential@n0)")
+edge_model(
+    device=device,
+    region=region,
+    name="DField:Potential@n0",
+    equation="diff(Permittivity*ElectricField, Potential@n0)",
+)
 
-edge_model(device=device, region=region, name="DField:Potential@n1",
-           equation="-DField:Potential@n0")
+edge_model(
+    device=device,
+    region=region,
+    name="DField:Potential@n1",
+    equation="-DField:Potential@n0",
+)
 
 ###
 ### Create the bulk equation
 ###
-equation(device=device, region=region, name="PotentialEquation", variable_name="Potential",
-         edge_model="DField", variable_update="default")
+equation(
+    device=device,
+    region=region,
+    name="PotentialEquation",
+    variable_name="Potential",
+    edge_model="DField",
+    variable_update="default",
+)
 
 
 ###
 ### Contact models and equations
 ###
 for c in ("top", "bot"):
-    contact_node_model(device=device, contact=c, name="%s_bc" % c,
-                       equation="Potential - %s_bias" % c)
+    contact_node_model(
+        device=device, contact=c, name="%s_bc" % c, equation="Potential - %s_bias" % c
+    )
 
-    contact_node_model(device=device, contact=c, name="%s_bc:Potential" % c,
-                       equation="1")
+    contact_node_model(
+        device=device, contact=c, name="%s_bc:Potential" % c, equation="1"
+    )
 
-    contact_equation(device=device, contact=c, name="PotentialEquation",
-                     node_model="%s_bc" % c, edge_charge_model="DField")
+    contact_equation(
+        device=device,
+        contact=c,
+        name="PotentialEquation",
+        node_model="%s_bc" % c,
+        edge_charge_model="DField",
+    )
 
 ###
 ### Set the contact
@@ -118,15 +176,20 @@ set_parameter(device=device, name="top_bias", value=1.0e-0)
 set_parameter(device=device, name="bot_bias", value=0.0)
 
 
-
 edge_model(device=device, region="m1", name="ElectricField", equation="0")
 edge_model(device=device, region="m2", name="ElectricField", equation="0")
 node_model(device=device, region="m1", name="Potential", equation="bot_bias;")
 node_model(device=device, region="m2", name="Potential", equation="top_bias;")
 
 
-#solve -type dc -absolute_error 1.0 -relative_error 1e-10 -maximum_iterations 100 -solver_type iterative
-solve(type="dc", absolute_error=1.0, relative_error=1e-10, maximum_iterations=30, solver_type="direct")
+# solve -type dc -absolute_error 1.0 -relative_error 1e-10 -maximum_iterations 100 -solver_type iterative
+solve(
+    type="dc",
+    absolute_error=1.0,
+    relative_error=1e-10,
+    maximum_iterations=30,
+    solver_type="direct",
+)
 
 element_from_edge_model(edge_model="ElectricField", device=device, region=region)
 print(get_contact_charge(device=device, contact="top", equation="PotentialEquation"))
@@ -135,4 +198,3 @@ print(get_contact_charge(device=device, contact="bot", equation="PotentialEquati
 write_devices(file="cap2d.msh", type="devsim")
 write_devices(file="cap2d.dat", type="tecplot")
 write_devices(file="cap2d", type="vtk")
-

--- a/examples/diode/diode_1d.py
+++ b/examples/diode/diode_1d.py
@@ -15,8 +15,8 @@ import diode_common
 # in dio2 add recombination
 #
 
-device="MyDevice"
-region="MyRegion"
+device = "MyDevice"
+region = "MyRegion"
 
 diode_common.CreateMesh(device=device, region=region)
 
@@ -53,42 +53,42 @@ while v < 0.51:
 
 write_devices(file="diode_1d.dat", type="tecplot")
 
-#import matplotlib
-#import matplotlib.pyplot
-#x=get_node_model_values(device=device, region=region, name="x")
-#ymax = 10
-#ymin = 10
-#fields = ("Electrons", "Holes", "Donors", "Acceptors")
-#for i in fields:
+# import matplotlib
+# import matplotlib.pyplot
+# x=get_node_model_values(device=device, region=region, name="x")
+# ymax = 10
+# ymin = 10
+# fields = ("Electrons", "Holes", "Donors", "Acceptors")
+# for i in fields:
 #    y=get_node_model_values(device=device, region=region, name=i)
 #    if (max(y) > ymax):
 #      ymax = max(y)
 #    matplotlib.pyplot.semilogy(x, y)
-#matplotlib.pyplot.xlabel('x (cm)')
-#matplotlib.pyplot.ylabel('Density (#/cm^3)')
-#matplotlib.pyplot.legend(fields)
-#ymax *= 10
-#matplotlib.pyplot.axis([min(x), max(x), ymin, ymax])
-#matplotlib.pyplot.savefig("diode_1d_density.eps")
+# matplotlib.pyplot.xlabel('x (cm)')
+# matplotlib.pyplot.ylabel('Density (#/cm^3)')
+# matplotlib.pyplot.legend(fields)
+# ymax *= 10
+# matplotlib.pyplot.axis([min(x), max(x), ymin, ymax])
+# matplotlib.pyplot.savefig("diode_1d_density.eps")
 #
-#matplotlib.pyplot.clf()
-#edge_average_model(device=device, region=region, node_model="x", edge_model="xmid")
-#xmid=get_edge_model_values(device=device, region=region, name="xmid")
-#efields = ("ElectronCurrent", "HoleCurrent", )
-#y=get_edge_model_values(device=device, region=region, name="ElectronCurrent")
-#ymin=min(y)
-#ymax=max(y)
-#for i in efields:
+# matplotlib.pyplot.clf()
+# edge_average_model(device=device, region=region, node_model="x", edge_model="xmid")
+# xmid=get_edge_model_values(device=device, region=region, name="xmid")
+# efields = ("ElectronCurrent", "HoleCurrent", )
+# y=get_edge_model_values(device=device, region=region, name="ElectronCurrent")
+# ymin=min(y)
+# ymax=max(y)
+# for i in efields:
 #  y=get_edge_model_values(device=device, region=region, name=i)
 #  if min(y) < ymin:
 #    ymin = min(y)
 #  elif max(y) > ymax:
 #    ymax = max(y)
 #  matplotlib.pyplot.plot(xmid, y)
-#matplotlib.pyplot.xlabel('x (cm)')
-#matplotlib.pyplot.ylabel('J (A/cm^2)')
-#matplotlib.pyplot.legend(efields)
-#matplotlib.pyplot.axis([min(x), max(x), 0.5*ymin, 2*ymax])
-#matplotlib.pyplot.savefig("diode_1d_current.eps")
-#print ymin
-#print ymax
+# matplotlib.pyplot.xlabel('x (cm)')
+# matplotlib.pyplot.ylabel('J (A/cm^2)')
+# matplotlib.pyplot.legend(efields)
+# matplotlib.pyplot.axis([min(x), max(x), 0.5*ymin, 2*ymax])
+# matplotlib.pyplot.savefig("diode_1d_current.eps")
+# print ymin
+# print ymax

--- a/examples/diode/diode_2d.py
+++ b/examples/diode/diode_2d.py
@@ -15,8 +15,8 @@ import diode_common
 # in dio2 add recombination
 #
 
-device="MyDevice"
-region="MyRegion"
+device = "MyDevice"
+region = "MyRegion"
 
 diode_common.Create2DMesh(device, region)
 
@@ -49,14 +49,20 @@ while v < 0.51:
 val = 10
 for i in range(2):
     set_parameter(device=device, name=GetContactBiasName("top"), value=val)
-    data = solve(type="dc", absolute_error=1e10, relative_error=1e-10, maximum_iterations=30, info=True)
-    print(data['converged'])
-    if not data['converged']:
-      val = 0.6
+    data = solve(
+        type="dc",
+        absolute_error=1e10,
+        relative_error=1e-10,
+        maximum_iterations=30,
+        info=True,
+    )
+    print(data["converged"])
+    if not data["converged"]:
+        val = 0.6
 
 print(data)
-for i in data['iterations']:
-    for d in i['devices']:
-        for r in d['regions']:
-            for e in r['equations']:
+for i in data["iterations"]:
+    for d in i["devices"]:
+        for r in d["regions"]:
+            for e in r["equations"]:
                 print(e)

--- a/examples/diode/diode_common.py
+++ b/examples/diode/diode_common.py
@@ -2,11 +2,35 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from devsim import add_1d_contact, add_1d_mesh_line, add_1d_region, add_2d_contact, add_2d_mesh_line, add_2d_region, add_gmsh_contact, add_gmsh_region, create_1d_mesh, create_2d_mesh, create_device, create_gmsh_mesh, finalize_mesh, get_contact_list, set_node_values, set_parameter
+from devsim import (
+    add_1d_contact,
+    add_1d_mesh_line,
+    add_1d_region,
+    add_2d_contact,
+    add_2d_mesh_line,
+    add_2d_region,
+    add_gmsh_contact,
+    add_gmsh_region,
+    create_1d_mesh,
+    create_2d_mesh,
+    create_device,
+    create_gmsh_mesh,
+    finalize_mesh,
+    get_contact_list,
+    set_node_values,
+    set_parameter,
+)
 
 from devsim.python_packages.model_create import CreateNodeModel, CreateSolution
 
-from devsim.python_packages.simple_physics import GetContactBiasName, SetSiliconParameters, CreateSiliconPotentialOnly, CreateSiliconPotentialOnlyContact, CreateSiliconDriftDiffusion, CreateSiliconDriftDiffusionAtContact
+from devsim.python_packages.simple_physics import (
+    GetContactBiasName,
+    SetSiliconParameters,
+    CreateSiliconPotentialOnly,
+    CreateSiliconPotentialOnlyContact,
+    CreateSiliconDriftDiffusion,
+    CreateSiliconDriftDiffusionAtContact,
+)
 #####
 # dio1
 #
@@ -16,19 +40,21 @@ from devsim.python_packages.simple_physics import GetContactBiasName, SetSilicon
 # in dio2 add recombination
 #
 
+
 def CreateMesh(device, region):
-    '''
-      Meshing
-    '''
+    """
+    Meshing
+    """
     create_1d_mesh(mesh="dio")
     add_1d_mesh_line(mesh="dio", pos=0, ps=1e-7, tag="top")
     add_1d_mesh_line(mesh="dio", pos=0.5e-5, ps=1e-9, tag="mid")
     add_1d_mesh_line(mesh="dio", pos=1e-5, ps=1e-7, tag="bot")
-    add_1d_contact  (mesh="dio", name="top", tag="top", material="metal")
-    add_1d_contact  (mesh="dio", name="bot", tag="bot", material="metal")
-    add_1d_region   (mesh="dio", material="Si", region=region, tag1="top", tag2="bot")
+    add_1d_contact(mesh="dio", name="top", tag="top", material="metal")
+    add_1d_contact(mesh="dio", name="bot", tag="bot", material="metal")
+    add_1d_region(mesh="dio", material="Si", region=region, tag1="top", tag2="bot")
     finalize_mesh(mesh="dio")
     create_device(mesh="dio", device=device)
+
 
 # this is the mesh for the ssac device
 # TODO: use CreateMesh and update regressions
@@ -43,60 +69,90 @@ def CreateMesh2(device, region):
     finalize_mesh(mesh="dio")
     create_device(mesh="dio", device=device)
 
+
 def Create2DMesh(device, region):
     create_2d_mesh(mesh="dio")
-    add_2d_mesh_line(mesh="dio", dir="x", pos=0,      ps=1e-6)
+    add_2d_mesh_line(mesh="dio", dir="x", pos=0, ps=1e-6)
     add_2d_mesh_line(mesh="dio", dir="x", pos=0.5e-5, ps=1e-8)
-    add_2d_mesh_line(mesh="dio", dir="x", pos=1e-5,   ps=1e-6)
-    add_2d_mesh_line(mesh="dio", dir="y", pos=0,      ps=1e-6)
-    add_2d_mesh_line(mesh="dio", dir="y", pos=1e-5,   ps=1e-6)
+    add_2d_mesh_line(mesh="dio", dir="x", pos=1e-5, ps=1e-6)
+    add_2d_mesh_line(mesh="dio", dir="y", pos=0, ps=1e-6)
+    add_2d_mesh_line(mesh="dio", dir="y", pos=1e-5, ps=1e-6)
 
-    add_2d_mesh_line(mesh="dio", dir="x", pos=-1e-8,    ps=1e-8)
+    add_2d_mesh_line(mesh="dio", dir="x", pos=-1e-8, ps=1e-8)
     add_2d_mesh_line(mesh="dio", dir="x", pos=1.001e-5, ps=1e-8)
 
     add_2d_region(mesh="dio", material="Si", region=region)
-    add_2d_region(mesh="dio", material="Si", region="air1", xl=-1e-8,  xh=0)
+    add_2d_region(mesh="dio", material="Si", region="air1", xl=-1e-8, xh=0)
     add_2d_region(mesh="dio", material="Si", region="air2", xl=1.0e-5, xh=1.001e-5)
 
-    add_2d_contact(mesh="dio", name="top", material="metal", region=region, yl=0.8e-5, yh=1e-5, xl=0, xh=0, bloat=1e-10)
-    add_2d_contact(mesh="dio", name="bot", material="metal", region=region, xl=1e-5,   xh=1e-5, bloat=1e-10)
+    add_2d_contact(
+        mesh="dio",
+        name="top",
+        material="metal",
+        region=region,
+        yl=0.8e-5,
+        yh=1e-5,
+        xl=0,
+        xh=0,
+        bloat=1e-10,
+    )
+    add_2d_contact(
+        mesh="dio",
+        name="bot",
+        material="metal",
+        region=region,
+        xl=1e-5,
+        xh=1e-5,
+        bloat=1e-10,
+    )
 
     finalize_mesh(mesh="dio")
     create_device(mesh="dio", device=device)
 
+
 def Create2DGmshMesh(device, region):
-    #this reads in the gmsh format
-    create_gmsh_mesh (mesh="diode2d", file="gmsh_diode2d.msh")
-    add_gmsh_region  (mesh="diode2d", gmsh_name="Bulk",    region=region, material="Silicon")
-    add_gmsh_contact (mesh="diode2d", gmsh_name="Base",    region=region, material="metal", name="top")
-    add_gmsh_contact (mesh="diode2d", gmsh_name="Emitter", region=region, material="metal", name="bot")
-    finalize_mesh    (mesh="diode2d")
-    create_device    (mesh="diode2d", device=device)
+    # this reads in the gmsh format
+    create_gmsh_mesh(mesh="diode2d", file="gmsh_diode2d.msh")
+    add_gmsh_region(mesh="diode2d", gmsh_name="Bulk", region=region, material="Silicon")
+    add_gmsh_contact(
+        mesh="diode2d", gmsh_name="Base", region=region, material="metal", name="top"
+    )
+    add_gmsh_contact(
+        mesh="diode2d", gmsh_name="Emitter", region=region, material="metal", name="bot"
+    )
+    finalize_mesh(mesh="diode2d")
+    create_device(mesh="diode2d", device=device)
+
 
 def Create3DGmshMesh(device, region):
-    #this reads in the gmsh format
-    create_gmsh_mesh (mesh="diode3d", file="gmsh_diode3d.msh")
-    add_gmsh_region  (mesh="diode3d", gmsh_name="Bulk",    region=region, material="Silicon")
-    add_gmsh_contact (mesh="diode3d", gmsh_name="Base",    region=region, material="metal", name="top")
-    add_gmsh_contact (mesh="diode3d", gmsh_name="Emitter", region=region, material="metal", name="bot")
-    finalize_mesh    (mesh="diode3d")
-    create_device    (mesh="diode3d", device=device)
+    # this reads in the gmsh format
+    create_gmsh_mesh(mesh="diode3d", file="gmsh_diode3d.msh")
+    add_gmsh_region(mesh="diode3d", gmsh_name="Bulk", region=region, material="Silicon")
+    add_gmsh_contact(
+        mesh="diode3d", gmsh_name="Base", region=region, material="metal", name="top"
+    )
+    add_gmsh_contact(
+        mesh="diode3d", gmsh_name="Emitter", region=region, material="metal", name="bot"
+    )
+    finalize_mesh(mesh="diode3d")
+    create_device(mesh="diode3d", device=device)
 
 
 def SetParameters(device, region):
-    '''
-      Set parameters for 300 K
-    '''
+    """
+    Set parameters for 300 K
+    """
     SetSiliconParameters(device, region, 300)
 
 
 def SetNetDoping(device, region):
-    '''
-      NetDoping
-    '''
+    """
+    NetDoping
+    """
     CreateNodeModel(device, region, "Acceptors", "1.0e18*step(0.5e-5-x)")
-    CreateNodeModel(device, region, "Donors",    "1.0e18*step(x-0.5e-5)")
+    CreateNodeModel(device, region, "Donors", "1.0e18*step(x-0.5e-5)")
     CreateNodeModel(device, region, "NetDoping", "Donors-Acceptors")
+
 
 def InitialSolution(device, region, circuit_contacts=None):
     # Create Potential, Potential@n0, Potential@n1
@@ -104,7 +160,6 @@ def InitialSolution(device, region, circuit_contacts=None):
 
     # Create potential only physical models
     CreateSiliconPotentialOnly(device, region)
-
 
     # Set up the contacts applying a bias
     for i in get_contact_list(device=device):
@@ -127,8 +182,12 @@ def DriftDiffusionInitialSolution(device, region, circuit_contacts=None):
     ####
     #### create initial guess from dc only solution
     ####
-    set_node_values(device=device, region=region, name="Electrons", init_from="IntrinsicElectrons")
-    set_node_values(device=device, region=region, name="Holes",     init_from="IntrinsicHoles")
+    set_node_values(
+        device=device, region=region, name="Electrons", init_from="IntrinsicElectrons"
+    )
+    set_node_values(
+        device=device, region=region, name="Holes", init_from="IntrinsicHoles"
+    )
 
     ###
     ### Set up equations
@@ -141,21 +200,18 @@ def DriftDiffusionInitialSolution(device, region, circuit_contacts=None):
             CreateSiliconDriftDiffusionAtContact(device, region, i)
 
 
-
-
-
 #####
 ##### Ramp the bias to 0.5 Volts
 #####
-#v = 0.0
-#while v < 0.51:
+# v = 0.0
+# while v < 0.51:
 #  set_parameter(device=device, name=GetContactBiasName("top"), value=v)
 #  solve(type="dc", absolute_error=1e10, relative_error=1e-10, maximum_iterations=30)
 #  PrintCurrents(device, "top")
 #  PrintCurrents(device, "bot")
 #  v += 0.1
 #
-#write_devices(file="diode_1d.dat", type="tecplot")
+# write_devices(file="diode_1d.dat", type="tecplot")
 ##import matplotlib
 ##import matplotlib.pyplot
 ##x=get_node_model_values(device=device, region=region, name="x")

--- a/examples/diode/gmsh_diode2d.py
+++ b/examples/diode/gmsh_diode2d.py
@@ -7,21 +7,25 @@ from devsim import node_model, set_parameter, solve, write_devices
 from devsim.python_packages.simple_physics import GetContactBiasName, PrintCurrents
 import diode_common
 
-device="diode2d"
-region="Bulk"
+device = "diode2d"
+region = "Bulk"
 
 diode_common.Create2DGmshMesh(device, region)
 
 # this is is the devsim format
-write_devices    (file="gmsh_diode2d_out.msh")
+write_devices(file="gmsh_diode2d_out.msh")
 
 diode_common.SetParameters(device=device, region=region)
 
 ####
 #### NetDoping
 ####
-node_model(device=device, region=region, name="Acceptors", equation="1.0e18*step(0.5e-5-y);")
-node_model(device=device, region=region, name="Donors"   , equation="1.0e18*step(y-0.5e-5);")
+node_model(
+    device=device, region=region, name="Acceptors", equation="1.0e18*step(0.5e-5-y);"
+)
+node_model(
+    device=device, region=region, name="Donors", equation="1.0e18*step(y-0.5e-5);"
+)
 node_model(device=device, region=region, name="NetDoping", equation="Donors-Acceptors;")
 
 diode_common.InitialSolution(device, region)
@@ -49,4 +53,3 @@ while v < 0.51:
 
 write_devices(file="gmsh_diode2d.dat", type="tecplot")
 write_devices(file="gmsh_diode2d_dd.msh", type="devsim")
-

--- a/examples/diode/gmsh_diode3d.py
+++ b/examples/diode/gmsh_diode3d.py
@@ -2,27 +2,37 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from devsim import element_from_edge_model, node_model, set_parameter, solve, write_devices
+from devsim import (
+    element_from_edge_model,
+    node_model,
+    set_parameter,
+    solve,
+    write_devices,
+)
 
 from devsim.python_packages.simple_physics import GetContactBiasName, PrintCurrents
 import diode_common
 
-device="diode3d"
-region="Bulk"
+device = "diode3d"
+region = "Bulk"
 
 
 diode_common.Create3DGmshMesh(device, region)
 
 # this is is the devsim format
-write_devices (file="gmsh_diode3d_out.msh")
+write_devices(file="gmsh_diode3d_out.msh")
 
 diode_common.SetParameters(device=device, region=region)
 
 ####
 #### NetDoping
 ####
-node_model(device=device, region=region, name="Acceptors", equation="1.0e18*step(0.5e-5-z);")
-node_model(device=device, region=region, name="Donors",    equation="1.0e18*step(z-0.5e-5);")
+node_model(
+    device=device, region=region, name="Acceptors", equation="1.0e18*step(0.5e-5-z);"
+)
+node_model(
+    device=device, region=region, name="Donors", equation="1.0e18*step(z-0.5e-5);"
+)
 node_model(device=device, region=region, name="NetDoping", equation="Donors-Acceptors;")
 
 diode_common.InitialSolution(device, region)
@@ -48,18 +58,17 @@ while v < 0.51:
     PrintCurrents(device, "bot")
     v += 0.1
 
-element_from_edge_model(edge_model="ElectricField",   device=device, region=region)
+element_from_edge_model(edge_model="ElectricField", device=device, region=region)
 element_from_edge_model(edge_model="ElectronCurrent", device=device, region=region)
-element_from_edge_model(edge_model="HoleCurrent",     device=device, region=region)
+element_from_edge_model(edge_model="HoleCurrent", device=device, region=region)
 
 write_devices(file="gmsh_diode3d_dd.dat", type="tecplot")
 write_devices(file="gmsh_diode3d_dd.msh", type="devsim")
 
-#element_from_node_model(node_model="node_index", device=device, region=region)
-#en0 = map(lambda x : int(x), get_element_model_values(name="node_index@en0", device=device, region=region))
-#en1 = map(lambda x : int(x), get_element_model_values(name="node_index@en1", device=device, region=region))
-#en2 = map(lambda x : int(x), get_element_model_values(name="node_index@en2", device=device, region=region))
-#en3 = map(lambda x : int(x), get_element_model_values(name="node_index@en3", device=device, region=region))
-#for i in range(len(en0)):
+# element_from_node_model(node_model="node_index", device=device, region=region)
+# en0 = map(lambda x : int(x), get_element_model_values(name="node_index@en0", device=device, region=region))
+# en1 = map(lambda x : int(x), get_element_model_values(name="node_index@en1", device=device, region=region))
+# en2 = map(lambda x : int(x), get_element_model_values(name="node_index@en2", device=device, region=region))
+# en3 = map(lambda x : int(x), get_element_model_values(name="node_index@en3", device=device, region=region))
+# for i in range(len(en0)):
 #  print "%d %d %d %d" % (en0[i], en1[i], en2[i], en3[i])
-

--- a/examples/diode/gmsh_diode3d_equil.py
+++ b/examples/diode/gmsh_diode3d_equil.py
@@ -7,22 +7,26 @@
 from devsim import node_model, solve, write_devices
 import diode_common
 
-device="diode3d"
-region="Bulk"
+device = "diode3d"
+region = "Bulk"
 
 
 diode_common.Create3DGmshMesh(device, region)
 
 # this is is the devsim format
-write_devices (file="gmsh_diode3d_out.msh")
+write_devices(file="gmsh_diode3d_out.msh")
 
 diode_common.SetParameters(device=device, region=region)
 
 ####
 #### NetDoping
 ####
-node_model(device=device, region=region, name="Acceptors", equation="1.0e18*step(0.5e-5-z);")
-node_model(device=device, region=region, name="Donors",    equation="1.0e18*step(z-0.5e-5);")
+node_model(
+    device=device, region=region, name="Acceptors", equation="1.0e18*step(0.5e-5-z);"
+)
+node_model(
+    device=device, region=region, name="Donors", equation="1.0e18*step(z-0.5e-5);"
+)
 node_model(device=device, region=region, name="NetDoping", equation="Donors-Acceptors;")
 
 diode_common.InitialSolution(device, region)
@@ -33,9 +37,7 @@ diode_common.InitialSolution(device, region)
 ####
 solve(type="dc", absolute_error=1.0, relative_error=1e-12, maximum_iterations=30)
 
-#element_from_edge_model(edge_model="ElectricField",   device=device, region=region)
-#element_from_edge_model(edge_model="ElectricField",   device=device, region=region, derivative="Potential")
+# element_from_edge_model(edge_model="ElectricField",   device=device, region=region)
+# element_from_edge_model(edge_model="ElectricField",   device=device, region=region, derivative="Potential")
 
 write_devices(file="gmsh_diode3d_equil.msh", type="devsim")
-
-

--- a/examples/diode/gmsh_diode3d_float128.py
+++ b/examples/diode/gmsh_diode3d_float128.py
@@ -3,36 +3,47 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import sys
-from devsim import element_from_edge_model, get_parameter, node_model, set_parameter, solve, write_devices
+from devsim import (
+    element_from_edge_model,
+    get_parameter,
+    node_model,
+    set_parameter,
+    solve,
+    write_devices,
+)
+from devsim.python_packages.simple_physics import GetContactBiasName, PrintCurrents
 
 
-if not get_parameter(name='info')['extended_precision']:
+if not get_parameter(name="info")["extended_precision"]:
     print("Extended precision support is not available with this version")
     sys.exit(0)
 
-set_parameter(name = "extended_solver", value=True)
-set_parameter(name = "extended_model", value=True)
-set_parameter(name = "extended_equation", value=True)
+set_parameter(name="extended_solver", value=True)
+set_parameter(name="extended_model", value=True)
+set_parameter(name="extended_equation", value=True)
 
-from devsim.python_packages.simple_physics import GetContactBiasName, PrintCurrents
-import diode_common
+import diode_common  # noqa: F401, E402
 
-device="diode3d"
-region="Bulk"
+device = "diode3d"
+region = "Bulk"
 
 
 diode_common.Create3DGmshMesh(device, region)
 
 # this is is the devsim format
-write_devices (file="gmsh_diode3d_out.msh")
+write_devices(file="gmsh_diode3d_out.msh")
 
 diode_common.SetParameters(device=device, region=region)
 
 ####
 #### NetDoping
 ####
-node_model(device=device, region=region, name="Acceptors", equation="1.0e18*step(0.5e-5-z);")
-node_model(device=device, region=region, name="Donors",    equation="1.0e18*step(z-0.5e-5);")
+node_model(
+    device=device, region=region, name="Acceptors", equation="1.0e18*step(0.5e-5-z);"
+)
+node_model(
+    device=device, region=region, name="Donors", equation="1.0e18*step(z-0.5e-5);"
+)
 node_model(device=device, region=region, name="NetDoping", equation="Donors-Acceptors;")
 
 diode_common.InitialSolution(device, region)
@@ -58,18 +69,17 @@ while v < 0.51:
     PrintCurrents(device, "bot")
     v += 0.1
 
-element_from_edge_model(edge_model="ElectricField",   device=device, region=region)
+element_from_edge_model(edge_model="ElectricField", device=device, region=region)
 element_from_edge_model(edge_model="ElectronCurrent", device=device, region=region)
-element_from_edge_model(edge_model="HoleCurrent",     device=device, region=region)
+element_from_edge_model(edge_model="HoleCurrent", device=device, region=region)
 
 write_devices(file="gmsh_diode3d_dd.dat", type="tecplot")
 write_devices(file="gmsh_diode3d_dd.msh", type="devsim")
 
-#element_from_node_model(node_model="node_index", device=device, region=region)
-#en0 = map(lambda x : int(x), get_element_model_values(name="node_index@en0", device=device, region=region))
-#en1 = map(lambda x : int(x), get_element_model_values(name="node_index@en1", device=device, region=region))
-#en2 = map(lambda x : int(x), get_element_model_values(name="node_index@en2", device=device, region=region))
-#en3 = map(lambda x : int(x), get_element_model_values(name="node_index@en3", device=device, region=region))
-#for i in range(len(en0)):
+# element_from_node_model(node_model="node_index", device=device, region=region)
+# en0 = map(lambda x : int(x), get_element_model_values(name="node_index@en0", device=device, region=region))
+# en1 = map(lambda x : int(x), get_element_model_values(name="node_index@en1", device=device, region=region))
+# en2 = map(lambda x : int(x), get_element_model_values(name="node_index@en2", device=device, region=region))
+# en3 = map(lambda x : int(x), get_element_model_values(name="node_index@en3", device=device, region=region))
+# for i in range(len(en0)):
 #  print "%d %d %d %d" % (en0[i], en1[i], en2[i], en3[i])
-

--- a/examples/diode/laux2d.py
+++ b/examples/diode/laux2d.py
@@ -4,7 +4,7 @@
 
 # The purpose is to verify our triangle element field calculation.
 # It is based on Laux's weighting scheme
-#@article{Laux:1985,
+# @article{Laux:1985,
 # author = {Laux, Steven E. and Byrnes, Robert G.},
 # title = {Semiconductor device simulation using generalized mobility models},
 # journal = {IBM J. Res. Dev.},
@@ -21,19 +21,10 @@
 # acmid = {1012099},
 # publisher = {IBM Corp.},
 # address = {Riverton, NJ, USA},
-#}
+# }
 
-import sys
-try:
-    import numpy
-    import numpy.linalg
-except:
-    print("numpy is not available with your installation and is not being run")
-    sys.exit(-1)
-
-
+import devsim
 from devsim import load_devices
-
 from laux_common import SetDimension, RunTest
 
 
@@ -46,9 +37,7 @@ number_test = -1
 
 RunTest(device, region, number_test, "ElectricField", "Potential")
 
-import devsim
 devsim.set_parameter(name="V_t", value=0.0259)
 devsim.set_parameter(name="mu_n", value=400)
 devsim.set_parameter(name="ElectronCharge", value=1.6e-19)
 RunTest(device, region, number_test, "ElectronCurrent", "Potential")
-

--- a/examples/diode/laux3d.py
+++ b/examples/diode/laux3d.py
@@ -4,7 +4,7 @@
 
 # The purpose is to verify our triangle element field calculation.
 # It is based on Laux's weighting scheme
-#@article{Laux:1985,
+# @article{Laux:1985,
 # author = {Laux, Steven E. and Byrnes, Robert G.},
 # title = {Semiconductor device simulation using generalized mobility models},
 # journal = {IBM J. Res. Dev.},
@@ -21,16 +21,8 @@
 # acmid = {1012099},
 # publisher = {IBM Corp.},
 # address = {Riverton, NJ, USA},
-#}
-
-import sys
-try:
-    import numpy
-    import numpy.linalg
-except:
-    print("numpy is not available with your installation and is not being run")
-    sys.exit(-1)
-
+# }
+import devsim
 
 from devsim import load_devices
 
@@ -48,19 +40,15 @@ nen = laux_common.nen
 dim = laux_common.dim
 
 
-
 # There are nee edges per tetrahedron
-#number_elements = len(scalar_efield)/laux_common.nee;
+# number_elements = len(scalar_efield)/laux_common.nee;
 
 
 number_test = -1
 
 RunTest(device, region, number_test, "ElectricField", "Potential")
 
-import devsim
 devsim.set_parameter(name="V_t", value=0.0259)
 devsim.set_parameter(name="mu_n", value=400)
 devsim.set_parameter(name="ElectronCharge", value=1.6e-19)
 RunTest(device, region, number_test, "ElectronCurrent", "Potential")
-
-

--- a/examples/diode/laux_common.py
+++ b/examples/diode/laux_common.py
@@ -4,7 +4,7 @@
 
 # The purpose is to verify our triangle element field calculation.
 # It is based on Laux's weighting scheme
-#@article{Laux:1985,
+# @article{Laux:1985,
 # author = {Laux, Steven E. and Byrnes, Robert G.},
 # title = {Semiconductor device simulation using generalized mobility models},
 # journal = {IBM J. Res. Dev.},
@@ -21,35 +21,43 @@
 # acmid = {1012099},
 # publisher = {IBM Corp.},
 # address = {Riverton, NJ, USA},
-#}
+# }
 
 
 import sys
 
 try:
     import numpy
-    import numpy.linalg
-except:
-    print("numpy is not available with your installation and is not being run")
-    sys.exit(0)
+except ImportError:
+    print(
+        "numpy is not available with your installation and is required for this program."
+    )
+    sys.exit(1)
 
 
-from devsim import element_from_edge_model, element_from_node_model, element_model, element_pair_from_edge_model, get_element_model_values
+from devsim import (
+    element_from_edge_model,
+    element_from_node_model,
+    element_model,
+    element_pair_from_edge_model,
+    get_element_model_values,
+)
 
 
 dim = None
 nee = None
 nen = None
-directions = ('x', 'y', 'z')
+directions = ("x", "y", "z")
+
 
 def SetDimension(dimension):
     global dim
     global nee
     global nen
     if dimension == 2:
-        dim = 2 # dimension
-        nee = 3 # number of edges per element
-        nen = 3 # number of nodes per element
+        dim = 2  # dimension
+        nee = 3  # number of edges per element
+        nen = 3  # number of nodes per element
     elif dimension == 3:
         dim = 3
         nee = 6
@@ -66,22 +74,22 @@ def GetElementData(element_index, node_indexes):
     # get nodes for each element edge 0, 1, 2, 3
     edge_node_list = []
     for j in range(nee):
-        index = nee*element_index + j
+        index = nee * element_index + j
         enodes = []
         for i in node_indexes:
             enodes.append(i[index])
         edge_node_list.append(enodes)
-    element_data['edge_node_list'] = edge_node_list
+    element_data["edge_node_list"] = edge_node_list
 
     # get the all of the node indexes on the element
     # also available using get_element_node_list
     nodes = sorted(edge_node_list[0])
-    element_data['node_indexes'] = nodes
+    element_data["node_indexes"] = nodes
 
     vmap = {}
     for i in range(nen):
         vmap[nodes[i]] = i
-    element_data['node_index_positions'] = vmap
+    element_data["node_index_positions"] = vmap
 
     # n0 and n1 indexes for each element edge head and tail
     node_to_edge_indexes = []
@@ -90,24 +98,25 @@ def GetElementData(element_index, node_indexes):
     for ni in nodes:
         edge_indexes = []
         for j in range(nee):
-            ei = nee*element_index + j
+            ei = nee * element_index + j
             if (n0_indexes[ei] == ni) or (n1_indexes[ei] == ni):
                 edge_indexes.append(j)
         node_to_edge_indexes.append(edge_indexes)
     # how each node index connects to which element edge
-    element_data['node_to_edge_indexes'] = node_to_edge_indexes
+    element_data["node_to_edge_indexes"] = node_to_edge_indexes
 
     # store the element index
-    element_data['element_index'] = element_index
+    element_data["element_index"] = element_index
     return element_data
+
 
 def GetNodeMatrices(element_data, unit_vectors):
     # create the matrix associated with a given node
     matrices = []
-    ei = element_data['element_index']
+    ei = element_data["element_index"]
     for i in range(nen):
-        edge_indexes = element_data['node_to_edge_indexes'][i]
-        M = numpy.zeros((dim,dim))
+        edge_indexes = element_data["node_to_edge_indexes"][i]
+        M = numpy.zeros((dim, dim))
         for j in range(dim):
             edge_index = nee * ei + edge_indexes[j]
             for k in range(dim):
@@ -115,15 +124,16 @@ def GetNodeMatrices(element_data, unit_vectors):
         matrices.append(M)
     return matrices
 
+
 def CalculateEField(element_data, scalar_efield):
     # calculate the vector field with respect to each scalar edge quantity
     # calculated for each of the nen nodes on the element
     vector_efields = []
-    ei = element_data['element_index']
-    matrices = element_data['matrices']
+    ei = element_data["element_index"]
+    matrices = element_data["matrices"]
     for i in range(nen):
-        edge_indexes = element_data['node_to_edge_indexes'][i]
-        B = numpy.zeros((dim,1))
+        edge_indexes = element_data["node_to_edge_indexes"][i]
+        B = numpy.zeros((dim, 1))
         for j in range(dim):
             edge_index = nee * ei + edge_indexes[j]
             B[j] = scalar_efield[edge_index]
@@ -131,21 +141,22 @@ def CalculateEField(element_data, scalar_efield):
         vector_efields.append(ans)
     return vector_efields
 
+
 def CalculateEFieldDerivatives(element_data, scalar_efield_derivatives):
     # handle the case for each node derivative
     # scalar fields are w.r.t. to n0 and n1 on each edge
     vector_efield_derivatives = []
-    ei = element_data['element_index']
-    matrices = element_data['matrices']
+    ei = element_data["element_index"]
+    matrices = element_data["matrices"]
     # These are the derivatives for all of the nodes of the whole element
-    node_indexes = element_data['node_indexes']
+    node_indexes = element_data["node_indexes"]
     for i in range(nen):
-        edge_indexes = element_data['node_to_edge_indexes'][i]
-        B = numpy.zeros((dim,nen))
+        edge_indexes = element_data["node_to_edge_indexes"][i]
+        B = numpy.zeros((dim, nen))
         for j in range(dim):
             edge_index = edge_indexes[j]
             input_edge_index = nee * ei + edge_index
-            edge_node_list = element_data['edge_node_list'][edge_index]
+            edge_node_list = element_data["edge_node_list"][edge_index]
             # these are the derivative nodes corresponding
             for k in range(nen):
                 # this is the node we are taking the derivative with respect to
@@ -163,11 +174,12 @@ def CalculateEFieldDerivatives(element_data, scalar_efield_derivatives):
         vector_efield_derivatives.append(ans)
     return vector_efield_derivatives
 
+
 def CalculateFinalValuesPairs(element_data, vector_efields, output0, output1):
-    ei = element_data['element_index']
-    node_indexes = element_data['node_indexes']
-    edge_node_list = element_data['edge_node_list']
-    node_index_positions = element_data['node_index_positions']
+    ei = element_data["element_index"]
+    _node_indexes = element_data["node_indexes"]
+    edge_node_list = element_data["edge_node_list"]
+    node_index_positions = element_data["node_index_positions"]
 
     outputs = [output0, output1]
 
@@ -176,25 +188,33 @@ def CalculateFinalValuesPairs(element_data, vector_efields, output0, output1):
         output_edge_index = nee * ei + edge_index
         for i, ii in enumerate(enodes[0:2]):
             # make sure node indexes are in proper range
-            val = numpy.transpose(vector_efields[node_index_positions[ii]][:,0])
+            val = numpy.transpose(vector_efields[node_index_positions[ii]][:, 0])
             outputs[i][output_edge_index, 0:dim] = val
 
-def CalculateFinalDerivativesPairs(element_data, vector_efield_derivatives, output0, output1):
-    ei = element_data['element_index']
-    node_indexes = element_data['node_indexes']
-    edge_node_list = element_data['edge_node_list']
-    node_index_positions = element_data['node_index_positions']
+
+def CalculateFinalDerivativesPairs(
+    element_data, vector_efield_derivatives, output0, output1
+):
+    ei = element_data["element_index"]
+    _node_indexes = element_data["node_indexes"]
+    edge_node_list = element_data["edge_node_list"]
+    node_index_positions = element_data["node_index_positions"]
 
     outputs = [output0, output1]
 
-    for edge_index in range(nee): # for each element edge
+    for edge_index in range(nee):  # for each element edge
         enodes = edge_node_list[edge_index]
         output_edge_index = nee * ei + edge_index
         for i, ii in enumerate(enodes[0:2]):
-            for k, kk in enumerate(enodes): # for the derivative nodes
-                val = numpy.transpose(vector_efield_derivatives[node_index_positions[ii]][:,node_index_positions[kk]])
-                row_stride = slice(dim*(k+1),dim*(k+2))
+            for k, kk in enumerate(enodes):  # for the derivative nodes
+                val = numpy.transpose(
+                    vector_efield_derivatives[node_index_positions[ii]][
+                        :, node_index_positions[kk]
+                    ]
+                )
+                row_stride = slice(dim * (k + 1), dim * (k + 2))
                 outputs[i][output_edge_index, row_stride] = val
+
 
 #    for i in range(nen):
 #        edge_indexes = node_to_edge_indexes_map[i]
@@ -214,32 +234,32 @@ def CalculateFinalDerivativesPairs(element_data, vector_efield_derivatives, outp
 #                        output[output_edge_index, row_stride] += val
 
 
-
 def CalculateFinalValues3D(element_data, vector_efields, output):
     # this is the weighted value from each node on the edge
-    ei = element_data['element_index']
-    #node_indexes = element_data['node_indexes']
-    #edge_node_list = element_data['edge_node_list']
-    node_to_edge_indexes_map = element_data['node_to_edge_indexes']
+    ei = element_data["element_index"]
+    # node_indexes = element_data['node_indexes']
+    # edge_node_list = element_data['edge_node_list']
+    node_to_edge_indexes_map = element_data["node_to_edge_indexes"]
     for i in range(nen):
         edge_indexes = node_to_edge_indexes_map[i]
-        #print len(edge_indexes)
-        #raise RuntimeError("STOP")
-        val = 0.5 * numpy.transpose(vector_efields[i][:,0])
+        # print len(edge_indexes)
+        # raise RuntimeError("STOP")
+        val = 0.5 * numpy.transpose(vector_efields[i][:, 0])
         for j in range(dim):
             edge_index = edge_indexes[j]
-            #if (abs(edge_index) > 5):
+            # if (abs(edge_index) > 5):
             #  raise RuntimeError("PROBLEM")
             output_edge_index = nee * ei + edge_index
-            output[output_edge_index,0:dim] += val
+            output[output_edge_index, 0:dim] += val
+
 
 def CalculateFinalDerivatives3D(element_data, vector_efield_derivatives, output):
     # this is the weighted value from each node on the edge
     # now for the derivatives
-    ei = element_data['element_index']
-    node_indexes = element_data['node_indexes']
-    edge_node_list = element_data['edge_node_list']
-    node_to_edge_indexes_map = element_data['node_to_edge_indexes']
+    ei = element_data["element_index"]
+    node_indexes = element_data["node_indexes"]
+    edge_node_list = element_data["edge_node_list"]
+    node_to_edge_indexes_map = element_data["node_to_edge_indexes"]
     for i in range(nen):
         edge_indexes = node_to_edge_indexes_map[i]
         for j in range(dim):
@@ -248,22 +268,23 @@ def CalculateFinalDerivatives3D(element_data, vector_efield_derivatives, output)
             for k in range(nen):
                 # this are the derivatives corresponding to the ordered list of nodes on the entire element
                 nk = node_indexes[k]
-                #val = 0.5 * numpy.transpose(vector_efield_derivatives[i][:][k])
-                val = 0.5 * numpy.transpose(vector_efield_derivatives[i][:,k])
+                # val = 0.5 * numpy.transpose(vector_efield_derivatives[i][:][k])
+                val = 0.5 * numpy.transpose(vector_efield_derivatives[i][:, k])
                 for kk in range(nen):
                     nkk = edge_node_list[edge_index][kk]
                     if nk == nkk:
-                        row_stride = slice(dim*(kk+1),dim*(kk+2))
-                        #print row_stride
+                        row_stride = slice(dim * (kk + 1), dim * (kk + 2))
+                        # print row_stride
                         output[output_edge_index, row_stride] += val
 
+
 def CalculateFinalValues2D(element_data, vector_efields, ecouple, output):
-    ei = element_data['element_index']
+    ei = element_data["element_index"]
     # this is special weighting based on edge away from edge of interest
-    wts  = numpy.zeros((nee,)) # this handles the weights summed into our edge
-    outs = numpy.zeros((nee,dim))
+    wts = numpy.zeros((nee,))  # this handles the weights summed into our edge
+    outs = numpy.zeros((nee, dim))
     # iterate over our element nodes
-    node_to_edge_indexes = element_data['node_to_edge_indexes']
+    node_to_edge_indexes = element_data["node_to_edge_indexes"]
     for i in range(nen):
         edge_indexes = node_to_edge_indexes[i]
         for j in edge_indexes:
@@ -272,20 +293,23 @@ def CalculateFinalValues2D(element_data, vector_efields, ecouple, output):
                     continue
                 wt = ecouple[nee * ei + k]
                 wts[j] += wt
-                outs[j] += wt * vector_efields[i][:,0]
+                outs[j] += wt * vector_efields[i][:, 0]
     for i in range(nee):
         outs[i] /= wts[i]
-        output[nee * ei + i,0:dim] = numpy.transpose(outs[i])
+        output[nee * ei + i, 0:dim] = numpy.transpose(outs[i])
 
-def CalculateFinalDerivatives2D(element_data, vector_efield_derivatives, ecouple, output):
-    ei = element_data['element_index']
+
+def CalculateFinalDerivatives2D(
+    element_data, vector_efield_derivatives, ecouple, output
+):
+    ei = element_data["element_index"]
     # this is special weighting based on edge away from edge of interest
-    wts  = numpy.zeros((nee,)) # this handles the weights summed into our edge
-    outs = numpy.zeros((nee,nen*dim))
+    wts = numpy.zeros((nee,))  # this handles the weights summed into our edge
+    outs = numpy.zeros((nee, nen * dim))
     # iterate over our element nodes
-    node_indexes = element_data['node_indexes']
-    node_to_edge_indexes = element_data['node_to_edge_indexes']
-    edge_node_list = element_data['edge_node_list']
+    node_indexes = element_data["node_indexes"]
+    node_to_edge_indexes = element_data["node_to_edge_indexes"]
+    edge_node_list = element_data["edge_node_list"]
     for i in range(nen):
         edge_indexes = node_to_edge_indexes[i]
         for j in edge_indexes:
@@ -294,11 +318,11 @@ def CalculateFinalDerivatives2D(element_data, vector_efield_derivatives, ecouple
                     continue
                 wt = ecouple[nee * ei + k]
                 wts[j] += wt
-                for l in range(nen):
-                    row_stride = slice(dim*l,dim*(l+1))
-                    outs[j,row_stride] += wt * vector_efield_derivatives[i][:,l]
-                    #outs[j,] += wt * vector_efields[i][:,0]
-                #val = 0.5 * numpy.transpose(vector_efield_derivatives[i][:,k])
+                for l in range(nen):  # noqa: E741
+                    row_stride = slice(dim * l, dim * (l + 1))
+                    outs[j, row_stride] += wt * vector_efield_derivatives[i][:, l]
+                    # outs[j,] += wt * vector_efields[i][:,0]
+                # val = 0.5 * numpy.transpose(vector_efield_derivatives[i][:,k])
     for i in range(nee):
         outs[i] /= wts[i]
         for k in range(nen):
@@ -306,17 +330,22 @@ def CalculateFinalDerivatives2D(element_data, vector_efield_derivatives, ecouple
             for kk in range(nen):
                 nkk = edge_node_list[i][kk]
                 if nk == nkk:
-                    row_stride1 = slice(dim*(kk+1),dim*(kk+2))
-                    row_stride2 = slice(dim*(k),dim*(k+1))
-                    #print row_stride1
-                    #print row_stride2
-                    output[nee * ei + i,row_stride1] = numpy.transpose(outs[i, row_stride2])
+                    row_stride1 = slice(dim * (kk + 1), dim * (kk + 2))
+                    row_stride2 = slice(dim * (k), dim * (k + 1))
+                    # print row_stride1
+                    # print row_stride2
+                    output[nee * ei + i, row_stride1] = numpy.transpose(
+                        outs[i, row_stride2]
+                    )
                     break
 
 
 def GetScalarField(device, region, name, mname):
     element_model(device=device, region=region, name=name, equation=mname)
-    return numpy.array(get_element_model_values(device=device, region=region, name=name))
+    return numpy.array(
+        get_element_model_values(device=device, region=region, name=name)
+    )
+
 
 def GetScalarFieldDerivatives(device, region, name, mname, vname):
     ret = []
@@ -332,7 +361,9 @@ def GetNodeIndexes(device, region):
     ret = []
     element_from_node_model(node_model="node_index", device=device, region=region)
     for i in range(nen):
-        tmp = get_element_model_values(device=device, region=region, name="node_index@en%d" % i)
+        tmp = get_element_model_values(
+            device=device, region=region, name="node_index@en%d" % i
+        )
         tmp = [int(x) for x in tmp]
         ret.append(tmp)
     return ret
@@ -342,81 +373,96 @@ def GetUnitVectors(device, region):
     ret = []
     for i in range(dim):
         mname = "s%s" % directions[i]
-        element_model(device=device, region=region, name=mname, equation="unit%s" % directions[i])
+        element_model(
+            device=device, region=region, name=mname, equation="unit%s" % directions[i]
+        )
         ret.append(get_element_model_values(device=device, region=region, name=mname))
     return ret
+
 
 def SetupOutputCompare(device, region, model, variable, output):
     k = 0
     for i in range(dim):
         mname = model + "_" + directions[i]
-        output[:,k] = numpy.array(get_element_model_values(device=device, region=region, name=mname))
+        output[:, k] = numpy.array(
+            get_element_model_values(device=device, region=region, name=mname)
+        )
         print("%d %s" % (k, mname))
         k += 1
     for j in range(nen):
         for i in range(dim):
             mname = model + "_" + directions[i]
             dname = mname + ":" + variable + "@en%d" % j
-            output[:,k] = numpy.array(get_element_model_values(device=device, region=region, name=dname))
+            output[:, k] = numpy.array(
+                get_element_model_values(device=device, region=region, name=dname)
+            )
             print("%d %s" % (k, dname))
             k += 1
 
+
 def DoCompare(output, output_compare, number_test):
-    test2 = output[0:nee*number_test] - output_compare[0:nee*number_test]
-    print(numpy.linalg.norm(test2, ord=numpy.inf ))
+    test2 = output[0 : nee * number_test] - output_compare[0 : nee * number_test]
+    print(numpy.linalg.norm(test2, ord=numpy.inf))
     for row in range(number_test):
-        for col in range(nen+1):
-            sl1 = slice(nee*row,nee*(row+1))
-            sl2 = slice(dim*col,dim*(col+1))
-            norm = numpy.linalg.norm(output[(sl1, sl2)]-output_compare[(sl1,sl2)])
+        for col in range(nen + 1):
+            sl1 = slice(nee * row, nee * (row + 1))
+            sl2 = slice(dim * col, dim * (col + 1))
+            norm = numpy.linalg.norm(output[(sl1, sl2)] - output_compare[(sl1, sl2)])
             if norm > 1e-4:
                 print("%d %d %g" % (row, col, norm))
 
     # use for debugging
     if True:
-        #for row in range(10):
+        # for row in range(10):
         row = 0
         col = 0
-        sl1 = slice(nee*row,nee*(row+1))
-        sl2 = slice(dim*col,dim*(col+1))
+        sl1 = slice(nee * row, nee * (row + 1))
+        sl2 = slice(dim * col, dim * (col + 1))
         print(output[(sl1, sl2)])
-        print(output_compare[(sl1,sl2)])
-        print(output[(sl1, sl2)] - output_compare[(sl1,sl2)])
+        print(output_compare[(sl1, sl2)])
+        print(output[(sl1, sl2)] - output_compare[(sl1, sl2)])
+
 
 def RunTest(device, region, number_test, scalar_field, derivative_variable):
     scalar_efield = GetScalarField(device, region, "scalar_efield", scalar_field)
-    scalar_efield_derivatives = GetScalarFieldDerivatives(device, region, "scalar_efield_n", scalar_field, derivative_variable)
+    scalar_efield_derivatives = GetScalarFieldDerivatives(
+        device, region, "scalar_efield_n", scalar_field, derivative_variable
+    )
     node_indexes = GetNodeIndexes(device, region)
     unit_vectors = GetUnitVectors(device, region)
 
-    number_elements = len(scalar_efield)//nee
+    number_elements = len(scalar_efield) // nee
 
     if number_test < 1:
         number_test = number_elements
 
-
-    output_dims = (nee*number_elements, dim*(nen+1))
+    output_dims = (nee * number_elements, dim * (nen + 1))
     output = numpy.zeros(output_dims)
     output0 = numpy.zeros(output_dims)
     output1 = numpy.zeros(output_dims)
 
-
     ecouple = None
     if dim == 2:
-        ecouple = get_element_model_values(device=device, region=region, name="ElementEdgeCouple")
+        ecouple = get_element_model_values(
+            device=device, region=region, name="ElementEdgeCouple"
+        )
 
     for ei in range(number_test):
         edata = GetElementData(ei, node_indexes)
 
-        edata['matrices'] = GetNodeMatrices(edata, unit_vectors)
+        edata["matrices"] = GetNodeMatrices(edata, unit_vectors)
 
         vector_efields = CalculateEField(edata, scalar_efield)
 
-        vector_efield_derivatives = CalculateEFieldDerivatives(edata, scalar_efield_derivatives)
+        vector_efield_derivatives = CalculateEFieldDerivatives(
+            edata, scalar_efield_derivatives
+        )
 
         if dim == 2:
             CalculateFinalValues2D(edata, vector_efields, ecouple, output)
-            CalculateFinalDerivatives2D(edata, vector_efield_derivatives, ecouple, output)
+            CalculateFinalDerivatives2D(
+                edata, vector_efield_derivatives, ecouple, output
+            )
         elif dim == 3:
             CalculateFinalValues3D(edata, vector_efields, output)
             CalculateFinalDerivatives3D(edata, vector_efield_derivatives, output)
@@ -424,21 +470,34 @@ def RunTest(device, region, number_test, scalar_field, derivative_variable):
             raise RuntimeError("Bad Dimension %d" % dim)
 
         CalculateFinalValuesPairs(edata, vector_efields, output0, output1)
-        CalculateFinalDerivativesPairs(edata, vector_efield_derivatives, output0, output1)
+        CalculateFinalDerivativesPairs(
+            edata, vector_efield_derivatives, output0, output1
+        )
 
     # For the averaged field
     element_from_edge_model(device=device, region=region, edge_model=scalar_field)
-    element_from_edge_model(device=device, region=region, edge_model=scalar_field, derivative=derivative_variable)
+    element_from_edge_model(
+        device=device,
+        region=region,
+        edge_model=scalar_field,
+        derivative=derivative_variable,
+    )
     output_compare = numpy.zeros(output_dims)
-    SetupOutputCompare(device, region, scalar_field, derivative_variable, output_compare)
+    SetupOutputCompare(
+        device, region, scalar_field, derivative_variable, output_compare
+    )
     DoCompare(output, output_compare, number_test)
 
     # For the node based fields
     element_pair_from_edge_model(device=device, region=region, edge_model=scalar_field)
-    element_pair_from_edge_model(device=device, region=region, edge_model=scalar_field, derivative=derivative_variable)
+    element_pair_from_edge_model(
+        device=device,
+        region=region,
+        edge_model=scalar_field,
+        derivative=derivative_variable,
+    )
     for i, v in enumerate((output0, output1)):
         output_compare = numpy.zeros(output_dims)
         n = scalar_field + ("_node%d" % i)
         SetupOutputCompare(device, region, n, derivative_variable, output_compare)
         DoCompare(v, output_compare, number_test)
-

--- a/examples/diode/pythonmesh3d.py
+++ b/examples/diode/pythonmesh3d.py
@@ -1,39 +1,61 @@
-from devsim import add_gmsh_contact, add_gmsh_region, create_device, create_gmsh_mesh, finalize_mesh, write_devices
+from devsim import (
+    add_gmsh_contact,
+    add_gmsh_region,
+    create_device,
+    create_gmsh_mesh,
+    finalize_mesh,
+    write_devices,
+)
 
 import devsim.python_packages.pythonmesh
 
 
-def gmsh_reader(mesh, device, filename="", coordinates="", physical_names="", elements=""):
-    if (filename):
+def gmsh_reader(
+    mesh, device, filename="", coordinates="", physical_names="", elements=""
+):
+    if filename:
         create_gmsh_mesh(mesh=mesh, file=filename)
     else:
-        create_gmsh_mesh(mesh=mesh, coordinates=coordinates, physical_names=physical_names, elements=elements)
-    add_gmsh_region  (mesh=mesh, gmsh_name="Bulk",    region="bulk", material="Silicon")
-    add_gmsh_contact (mesh=mesh, gmsh_name="Base",    region="bulk", material="metal", name="top")
-    add_gmsh_contact (mesh=mesh, gmsh_name="Emitter", region="bulk", material="metal", name="bot")
-    finalize_mesh    (mesh=mesh)
-    create_device    (mesh=mesh, device=device)
+        create_gmsh_mesh(
+            mesh=mesh,
+            coordinates=coordinates,
+            physical_names=physical_names,
+            elements=elements,
+        )
+    add_gmsh_region(mesh=mesh, gmsh_name="Bulk", region="bulk", material="Silicon")
+    add_gmsh_contact(
+        mesh=mesh, gmsh_name="Base", region="bulk", material="metal", name="top"
+    )
+    add_gmsh_contact(
+        mesh=mesh, gmsh_name="Emitter", region="bulk", material="metal", name="bot"
+    )
+    finalize_mesh(mesh=mesh)
+    create_device(mesh=mesh, device=device)
+
 
 data = devsim.python_packages.pythonmesh.read_gmsh_file("gmsh_diode3d.msh")
-coordinates=data['coordinates']
-elements=data['elements']
-physical_names=data['physical_names']
+coordinates = data["coordinates"]
+elements = data["elements"]
+physical_names = data["physical_names"]
 
-gmsh_reader(mesh="gmsh_diode3da", device="gmsh_diode3da", coordinates=coordinates, physical_names=physical_names, elements=elements)
+gmsh_reader(
+    mesh="gmsh_diode3da",
+    device="gmsh_diode3da",
+    coordinates=coordinates,
+    physical_names=physical_names,
+    elements=elements,
+)
 gmsh_reader(mesh="gmsh_diode3db", device="gmsh_diode3db", filename="gmsh_diode3d.msh")
 
 write_devices(device="gmsh_diode3da", file="gmsh_diode3da.msh")
 write_devices(device="gmsh_diode3db", file="gmsh_diode3db.msh")
 
-with open('gmsh_diode3da.msh', 'r') as f:
+with open("gmsh_diode3da.msh", "r") as f:
     file1 = f.read()
-with open('gmsh_diode3db.msh', 'r') as f:
+with open("gmsh_diode3db.msh", "r") as f:
     file2 = f.read()
 
-file2=file2.replace('gmsh_diode3db', 'gmsh_diode3da')
+file2 = file2.replace("gmsh_diode3db", "gmsh_diode3da")
 
-if (file1 != file2):
-    raise RuntimeError('gmsh_diode3da.msh and gmsh_diode3db.msh do not match')
-
-
-
+if file1 != file2:
+    raise RuntimeError("gmsh_diode3da.msh and gmsh_diode3db.msh do not match")

--- a/examples/diode/ssac_diode.py
+++ b/examples/diode/ssac_diode.py
@@ -3,21 +3,27 @@
 # SPDX-License-Identifier: Apache-2.0
 
 #### Small Signal simulation
-from devsim import circuit_alter, circuit_element, get_circuit_node_list, get_circuit_node_value, get_circuit_solution_list, solve
+from devsim import (
+    circuit_alter,
+    circuit_element,
+    get_circuit_node_list,
+    get_circuit_node_value,
+    get_circuit_solution_list,
+    solve,
+)
 
 from devsim.python_packages.simple_physics import GetContactBiasName, PrintCurrents
 import diode_common
 import math
 
-#This requires a circuit element to integrated current
-circuit_element(name="V1", n1=GetContactBiasName("top"), n2=0, value=0.0, acreal=1.0, acimag=0.0)
+# This requires a circuit element to integrated current
+circuit_element(
+    name="V1", n1=GetContactBiasName("top"), n2=0, value=0.0, acreal=1.0, acimag=0.0
+)
 
 
-
-
-
-device="MyDevice"
-region="MyRegion"
+device = "MyDevice"
+region = "MyRegion"
 
 diode_common.CreateMesh2(device, region)
 
@@ -33,15 +39,15 @@ solve(type="dc", absolute_error=1.0, relative_error=1e-12, maximum_iterations=30
 
 diode_common.DriftDiffusionInitialSolution(device, region, circuit_contacts=["top"])
 
-v=0.0
+v = 0.0
 while v < 0.51:
     circuit_alter(name="V1", value=v)
     solve(type="dc", absolute_error=1e10, relative_error=1e-10, maximum_iterations=30)
-    #TODO: get out circuit information
-#  PrintCurrents(device, "top")
+    # TODO: get out circuit information
+    #  PrintCurrents(device, "top")
     PrintCurrents(device, "bot")
     solve(type="ac", frequency=1.0)
-    cap=get_circuit_node_value(node="V1.I", solution="ssac_imag")/ (-2*math.pi)
+    cap = get_circuit_node_value(node="V1.I", solution="ssac_imag") / (-2 * math.pi)
     print("capacitance {0} {1}".format(v, cap))
     v += 0.1
 
@@ -49,4 +55,3 @@ for x in get_circuit_node_list():
     for y in get_circuit_solution_list():
         z = get_circuit_node_value(node=x, solution=y)
         print(("{0}\t{1}\t{2}".format(x, y, z)))
-

--- a/examples/diode/tran_diode.py
+++ b/examples/diode/tran_diode.py
@@ -2,27 +2,31 @@ import devsim
 from devsim.python_packages.simple_physics import GetContactBiasName
 import diode_common
 
+
 def print_circuit_solution():
-    for node in get_circuit_node_list():
-        r = get_circuit_node_value(solution='dcop', node=node)
+    for node in devsim.get_circuit_node_list():
+        r = devsim.get_circuit_node_value(solution="dcop", node=node)
         print("%s\t%1.15e" % (node, r))
+
 
 device = "MyDevice"
 region = "MyRegion"
 
 # Set extended parameters
-set_parameter(name="extended_solver", value=True)
-set_parameter(name="extended_model", value=True)
-set_parameter(name="extended_equation", value=True)
+devsim.set_parameter(name="extended_solver", value=True)
+devsim.set_parameter(name="extended_model", value=True)
+devsim.set_parameter(name="extended_equation", value=True)
 
-#This requires a circuit element to integrated current
+# This requires a circuit element to integrated current
 voltage = 0.0
-circuit_element(name="V1", n1=GetContactBiasName("top"), n2=0, value=voltage, acreal=1.0, acimag=0.0)
+devsim.circuit_element(
+    name="V1", n1=GetContactBiasName("top"), n2=0, value=voltage, acreal=1.0, acimag=0.0
+)
 
 diode_common.CreateMesh2(device=device, region=region)
 diode_common.SetParameters(device=device, region=region)
 
-#Übergeben der Werte an SetNetDoping
+# Übergeben der Werte an SetNetDoping
 diode_common.SetNetDoping(device=device, region=region)
 
 diode_common.InitialSolution(device, region, circuit_contacts="top")
@@ -32,18 +36,27 @@ devsim.solve(type="dc", absolute_error=1.0, relative_error=1e-12, maximum_iterat
 
 diode_common.DriftDiffusionInitialSolution(device, region, circuit_contacts=["top"])
 
-devsim.solve(type="transient_dc", absolute_error=1.0, relative_error=1e-14, maximum_iterations=30)
+devsim.solve(
+    type="transient_dc", absolute_error=1.0, relative_error=1e-14, maximum_iterations=30
+)
 
 print_circuit_solution()
 
-circuit_alter(name="V1", value=0.7)
+devsim.circuit_alter(name="V1", value=0.7)
 
 time_step = 1e-3
 total_time = 1e-2
 current_time = 0
 
 while current_time < total_time:
-    devsim.solve(type="transient_bdf1", absolute_error=1e10, relative_error=1e-10, maximum_iterations=30, tdelta=time_step, charge_error=1)
+    devsim.solve(
+        type="transient_bdf1",
+        absolute_error=1e10,
+        relative_error=1e-10,
+        maximum_iterations=30,
+        tdelta=time_step,
+        charge_error=1,
+    )
 
     print_circuit_solution()
 

--- a/examples/mobility/gmsh_mos2d.py
+++ b/examples/mobility/gmsh_mos2d.py
@@ -2,14 +2,33 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from devsim.python_packages.simple_physics import GetContactBiasName, SetOxideParameters, SetSiliconParameters, CreateSiliconPotentialOnly, CreateSiliconPotentialOnlyContact, CreateSiliconDriftDiffusion, CreateSiliconDriftDiffusionAtContact, CreateOxidePotentialOnly, CreateSiliconOxideInterface
+from devsim.python_packages.simple_physics import (
+    GetContactBiasName,
+    SetOxideParameters,
+    SetSiliconParameters,
+    CreateSiliconPotentialOnly,
+    CreateSiliconPotentialOnlyContact,
+    CreateSiliconDriftDiffusion,
+    CreateSiliconDriftDiffusionAtContact,
+    CreateOxidePotentialOnly,
+    CreateSiliconOxideInterface,
+)
 from devsim.python_packages.ramp import rampbias, printAllCurrents
-from devsim import element_from_edge_model, get_contact_list, get_region_list, node_model, set_node_values, set_parameter, solve, write_devices
+from devsim import (
+    element_from_edge_model,
+    get_contact_list,
+    get_region_list,
+    node_model,
+    set_node_values,
+    set_parameter,
+    solve,
+    write_devices,
+)
 from devsim.python_packages.model_create import CreateSolution
 
 device = "mos2d"
-silicon_regions=("gate", "bulk")
-oxide_regions=("oxide",)
+silicon_regions = ("gate", "bulk")
+oxide_regions = ("oxide",)
 regions = ("gate", "bulk", "oxide")
 interfaces = ("bulk_oxide", "gate_oxide")
 
@@ -45,8 +64,10 @@ write_devices(file="gmsh_mos2d_potentialonly", type="vtk")
 for i in silicon_regions:
     CreateSolution(device, i, "Electrons")
     CreateSolution(device, i, "Holes")
-    set_node_values(device=device, region=i, name="Electrons", init_from="IntrinsicElectrons")
-    set_node_values(device=device, region=i, name="Holes",     init_from="IntrinsicHoles")
+    set_node_values(
+        device=device, region=i, name="Electrons", init_from="IntrinsicElectrons"
+    )
+    set_node_values(device=device, region=i, name="Holes", init_from="IntrinsicHoles")
     CreateSiliconDriftDiffusion(device, i, "mu_n", "mu_p")
 
 for c in contacts:
@@ -57,16 +78,17 @@ for c in contacts:
 solve(type="dc", absolute_error=1.0e30, relative_error=1e-5, maximum_iterations=30)
 
 for r in silicon_regions:
-    node_model(device=device, region=r, name="logElectrons", equation="log(Electrons)/log(10)")
+    node_model(
+        device=device, region=r, name="logElectrons", equation="log(Electrons)/log(10)"
+    )
 
 
 for r in silicon_regions:
-    element_from_edge_model(edge_model="ElectricField",   device=device, region=r)
+    element_from_edge_model(edge_model="ElectricField", device=device, region=r)
     element_from_edge_model(edge_model="ElectronCurrent", device=device, region=r)
-    element_from_edge_model(edge_model="HoleCurrent",     device=device, region=r)
+    element_from_edge_model(edge_model="HoleCurrent", device=device, region=r)
 #
-rampbias(device, "gate",  0.5, 0.5, 0.001, 100, 1e-10, 1e30, printAllCurrents)
+rampbias(device, "gate", 0.5, 0.5, 0.001, 100, 1e-10, 1e30, printAllCurrents)
 rampbias(device, "drain", 0.5, 0.1, 0.001, 100, 1e-10, 1e30, printAllCurrents)
 #
 write_devices(file="gmsh_mos2d_dd.dat", type="tecplot")
-

--- a/examples/mobility/gmsh_mos2d_create.py
+++ b/examples/mobility/gmsh_mos2d_create.py
@@ -2,73 +2,110 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from devsim import add_gmsh_contact, add_gmsh_interface, add_gmsh_region, create_device, create_gmsh_mesh, finalize_mesh, node_model, write_devices
+from devsim import (
+    add_gmsh_contact,
+    add_gmsh_interface,
+    add_gmsh_region,
+    create_device,
+    create_gmsh_mesh,
+    finalize_mesh,
+    node_model,
+    write_devices,
+)
 
-device ="mos2d"
+device = "mos2d"
 
-device_width    =1.0e-4
-gate_width      =1.0e-5
-diffusion_width =0.4
+device_width = 1.0e-4
+gate_width = 1.0e-5
+diffusion_width = 0.4
 
-air_thickness       =1e-7
-oxide_thickness     =1e-5
-gate_thickness      =1e-5
-device_thickness    =1e-4
-diffusion_thickness =1e-5
+air_thickness = 1e-7
+oxide_thickness = 1e-5
+gate_thickness = 1e-5
+device_thickness = 1e-4
+diffusion_thickness = 1e-5
 
-x_diffusion_decay  =1e-20
-y_diffusion_decay  =1e-10
+x_diffusion_decay = 1e-20
+y_diffusion_decay = 1e-10
 
-#p doping
-bulk_doping        =1e15
-body_doping        =1e19
-#n doping
-drain_doping       =1e19
-source_doping      =1e19
-gate_doping        =1e20
+# p doping
+bulk_doping = 1e15
+body_doping = 1e19
+# n doping
+drain_doping = 1e19
+source_doping = 1e19
+gate_doping = 1e20
 
-y_channel_spacing     =1e-8
-y_diffusion_spacing   =1e-6
-y_gate_top_spacing    =1e-8
-y_gate_mid_spacing    =gate_thickness * 0.25
-y_gate_bot_spacing    =1e-8
-y_oxide_mid_spacing   =oxide_thickness * 0.25
-x_channel_spacing     =1e-6
-x_diffusion_spacing   =1e-5
-max_y_spacing         =1e-4
-max_x_spacing         =1e-2
-y_bulk_mid_spacing =device_thickness * 0.25
-y_bulk_bottom_spacing =1e-8
+y_channel_spacing = 1e-8
+y_diffusion_spacing = 1e-6
+y_gate_top_spacing = 1e-8
+y_gate_mid_spacing = gate_thickness * 0.25
+y_gate_bot_spacing = 1e-8
+y_oxide_mid_spacing = oxide_thickness * 0.25
+x_channel_spacing = 1e-6
+x_diffusion_spacing = 1e-5
+max_y_spacing = 1e-4
+max_x_spacing = 1e-2
+y_bulk_mid_spacing = device_thickness * 0.25
+y_bulk_bottom_spacing = 1e-8
 
-x_bulk_left   =0.0
-x_bulk_right  =x_bulk_left + device_width
-x_center      =0.5 * (x_bulk_left + x_bulk_right)
-x_gate_left   =x_center - 0.5 * (gate_width)
-x_gate_right  =x_center + 0.5 * (gate_width)
-x_device_left =x_bulk_left - air_thickness
-x_device_right =x_bulk_right + air_thickness
+x_bulk_left = 0.0
+x_bulk_right = x_bulk_left + device_width
+x_center = 0.5 * (x_bulk_left + x_bulk_right)
+x_gate_left = x_center - 0.5 * (gate_width)
+x_gate_right = x_center + 0.5 * (gate_width)
+x_device_left = x_bulk_left - air_thickness
+x_device_right = x_bulk_right + air_thickness
 
-y_bulk_top      =0.0
-y_oxide_top     =y_bulk_top - oxide_thickness
-y_oxide_mid     =0.5 * (y_oxide_top + y_bulk_top)
-y_gate_top      =y_oxide_top - gate_thickness
-y_gate_mid      =0.5 * (y_gate_top + y_oxide_top)
-y_device_top    =y_gate_top - air_thickness
-y_bulk_bottom   =y_bulk_top + device_thickness
-y_bulk_mid      =0.5 * (y_bulk_top + y_bulk_bottom)
-y_device_bottom =y_bulk_bottom + air_thickness
-y_diffusion     =y_bulk_top + diffusion_thickness
+y_bulk_top = 0.0
+y_oxide_top = y_bulk_top - oxide_thickness
+y_oxide_mid = 0.5 * (y_oxide_top + y_bulk_top)
+y_gate_top = y_oxide_top - gate_thickness
+y_gate_mid = 0.5 * (y_gate_top + y_oxide_top)
+y_device_top = y_gate_top - air_thickness
+y_bulk_bottom = y_bulk_top + device_thickness
+y_bulk_mid = 0.5 * (y_bulk_top + y_bulk_bottom)
+y_device_bottom = y_bulk_bottom + air_thickness
+y_diffusion = y_bulk_top + diffusion_thickness
 
 create_gmsh_mesh(file="gmsh_mos2d.msh", mesh="mos2d")
-add_gmsh_region    (mesh="mos2d", gmsh_name="bulk",    region="bulk", material="Silicon")
-add_gmsh_region    (mesh="mos2d", gmsh_name="oxide",    region="oxide", material="Silicon")
-add_gmsh_region    (mesh="mos2d", gmsh_name="gate",    region="gate", material="Silicon")
-add_gmsh_contact   (mesh="mos2d", gmsh_name="drain_contact",  region="bulk", name="drain", material="metal")
-add_gmsh_contact   (mesh="mos2d", gmsh_name="source_contact", region="bulk", name="source", material="metal")
-add_gmsh_contact   (mesh="mos2d", gmsh_name="body_contact",   region="bulk", name="body", material="metal")
-add_gmsh_contact   (mesh="mos2d", gmsh_name="gate_contact",   region="gate", name="gate", material="metal")
-add_gmsh_interface (mesh="mos2d", gmsh_name="gate_oxide_interface", region0="gate", region1="oxide", name="gate_oxide")
-add_gmsh_interface (mesh="mos2d", gmsh_name="bulk_oxide_interface", region0="bulk", region1="oxide", name="bulk_oxide")
+add_gmsh_region(mesh="mos2d", gmsh_name="bulk", region="bulk", material="Silicon")
+add_gmsh_region(mesh="mos2d", gmsh_name="oxide", region="oxide", material="Silicon")
+add_gmsh_region(mesh="mos2d", gmsh_name="gate", region="gate", material="Silicon")
+add_gmsh_contact(
+    mesh="mos2d",
+    gmsh_name="drain_contact",
+    region="bulk",
+    name="drain",
+    material="metal",
+)
+add_gmsh_contact(
+    mesh="mos2d",
+    gmsh_name="source_contact",
+    region="bulk",
+    name="source",
+    material="metal",
+)
+add_gmsh_contact(
+    mesh="mos2d", gmsh_name="body_contact", region="bulk", name="body", material="metal"
+)
+add_gmsh_contact(
+    mesh="mos2d", gmsh_name="gate_contact", region="gate", name="gate", material="metal"
+)
+add_gmsh_interface(
+    mesh="mos2d",
+    gmsh_name="gate_oxide_interface",
+    region0="gate",
+    region1="oxide",
+    name="gate_oxide",
+)
+add_gmsh_interface(
+    mesh="mos2d",
+    gmsh_name="bulk_oxide_interface",
+    region0="bulk",
+    region1="oxide",
+    name="bulk_oxide",
+)
 finalize_mesh(mesh="mos2d")
 create_device(mesh="mos2d", device="mos2d")
 
@@ -86,16 +123,52 @@ mydict["y_diffusion"] = y_diffusion
 mydict["y_bulk_bottom"] = y_bulk_bottom
 mydict["y_diffusion_decay"] = y_diffusion_decay
 
-node_model(name="Donors",    device=device, region="gate", equation="%(gate_doping)1.15e + 1" % (mydict))
+node_model(
+    name="Donors",
+    device=device,
+    region="gate",
+    equation="%(gate_doping)1.15e + 1" % (mydict),
+)
 node_model(name="Acceptors", device=device, region="gate", equation="1")
-node_model(name="NetDoping",    device=device, region="gate", equation="Donors - Acceptors")
+node_model(
+    name="NetDoping", device=device, region="gate", equation="Donors - Acceptors"
+)
 
-node_model(name="DrainDoping",  device=device, region="bulk", equation="0.25*%(drain_doping)1.15e*erfc((x-%(x_gate_left)1.15e)/%(x_diffusion_decay)1.15e)*erfc((y-%(y_diffusion)1.15e)/%(y_diffusion_decay)1.15e)" % mydict)
-node_model(name="SourceDoping", device=device, region="bulk", equation="0.25*%(source_doping)1.15e*erfc(-(x-%(x_gate_right)1.15e)/%(x_diffusion_decay)1.15e)*erfc((y-%(y_diffusion)1.15e)/%(y_diffusion_decay)1.15e)" % mydict)
-node_model(name="BodyDoping",   device=device, region="bulk", equation="0.5*%(body_doping)1.15e*erfc(-(y-%(y_bulk_bottom)1.15e)/%(y_diffusion_decay)1.15e)" % mydict)
-node_model(name="Donors",       device=device, region="bulk", equation="DrainDoping + SourceDoping + 1")
-node_model(name="Acceptors",    device=device, region="bulk", equation="%(bulk_doping)1.15e + BodyDoping" % mydict)
-node_model(name="NetDoping",    device=device, region="bulk", equation="Donors - Acceptors")
+node_model(
+    name="DrainDoping",
+    device=device,
+    region="bulk",
+    equation="0.25*%(drain_doping)1.15e*erfc((x-%(x_gate_left)1.15e)/%(x_diffusion_decay)1.15e)*erfc((y-%(y_diffusion)1.15e)/%(y_diffusion_decay)1.15e)"
+    % mydict,
+)
+node_model(
+    name="SourceDoping",
+    device=device,
+    region="bulk",
+    equation="0.25*%(source_doping)1.15e*erfc(-(x-%(x_gate_right)1.15e)/%(x_diffusion_decay)1.15e)*erfc((y-%(y_diffusion)1.15e)/%(y_diffusion_decay)1.15e)"
+    % mydict,
+)
+node_model(
+    name="BodyDoping",
+    device=device,
+    region="bulk",
+    equation="0.5*%(body_doping)1.15e*erfc(-(y-%(y_bulk_bottom)1.15e)/%(y_diffusion_decay)1.15e)"
+    % mydict,
+)
+node_model(
+    name="Donors",
+    device=device,
+    region="bulk",
+    equation="DrainDoping + SourceDoping + 1",
+)
+node_model(
+    name="Acceptors",
+    device=device,
+    region="bulk",
+    equation="%(bulk_doping)1.15e + BodyDoping" % mydict,
+)
+node_model(
+    name="NetDoping", device=device, region="bulk", equation="Donors - Acceptors"
+)
 
 write_devices(file="gmsh_mos2d_out.msh")
-

--- a/examples/mobility/gmsh_mos2d_kla.py
+++ b/examples/mobility/gmsh_mos2d_kla.py
@@ -2,22 +2,52 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-#set_parameter -name threads_available -value 1
-#set_parameter -name threads_task_size -value 1024
-from devsim import get_contact_list, get_parameter, get_region_list, node_model, set_node_values, set_parameter, solve, vector_element_model, write_devices
+# set_parameter -name threads_available -value 1
+# set_parameter -name threads_task_size -value 1024
+from devsim import (
+    get_contact_list,
+    get_parameter,
+    get_region_list,
+    node_model,
+    set_node_values,
+    set_parameter,
+    solve,
+    vector_element_model,
+    write_devices,
+)
 
-from devsim.python_packages.simple_physics import GetContactBiasName, SetOxideParameters, SetSiliconParameters, CreateSiliconPotentialOnly, CreateSiliconPotentialOnlyContact, CreateSiliconDriftDiffusion, CreateSiliconDriftDiffusionAtContact, CreateOxidePotentialOnly, CreateSiliconOxideInterface
+from devsim.python_packages.simple_physics import (
+    GetContactBiasName,
+    SetOxideParameters,
+    SetSiliconParameters,
+    CreateSiliconPotentialOnly,
+    CreateSiliconPotentialOnlyContact,
+    CreateSiliconDriftDiffusion,
+    CreateSiliconDriftDiffusionAtContact,
+    CreateOxidePotentialOnly,
+    CreateSiliconOxideInterface,
+)
 from devsim.python_packages.ramp import rampbias, printAllCurrents
-from devsim.python_packages.Klaassen import Set_Mobility_Parameters, Klaassen_Mobility, Philips_VelocitySaturation, Philips_Surface_Mobility
-from devsim.python_packages.mos_physics import CreateElementElectronContinuityEquation, CreateElementContactElectronContinuityEquation, CreateNormalElectricFieldFromCurrentFlow, CreateElementElectronCurrent2d
+from devsim.python_packages.Klaassen import (
+    Set_Mobility_Parameters,
+    Klaassen_Mobility,
+    Philips_VelocitySaturation,
+    Philips_Surface_Mobility,
+)
+from devsim.python_packages.mos_physics import (
+    CreateElementElectronContinuityEquation,
+    CreateElementContactElectronContinuityEquation,
+    CreateNormalElectricFieldFromCurrentFlow,
+    CreateElementElectronCurrent2d,
+)
 from devsim.python_packages.model_create import CreateSolution, CreateElementModel2d
 
-import gmsh_mos2d_create
+import gmsh_mos2d_create  # noqa: F401
 
 # TODO: write out mesh, and then read back in as separate test
 device = "mos2d"
-silicon_regions=("gate", "bulk")
-oxide_regions=("oxide",)
+silicon_regions = ("gate", "bulk")
+oxide_regions = ("oxide",)
 regions = ("gate", "bulk", "oxide")
 interfaces = ("bulk_oxide", "gate_oxide")
 
@@ -44,7 +74,7 @@ for i in contacts:
 for i in interfaces:
     CreateSiliconOxideInterface(device, i)
 
-#for d in get_device_list():
+# for d in get_device_list():
 #  for gn in get_parameter_list():
 #    print("{0} {1}").format(gn, get_parameter(device=d, name=gn))
 #  for gn in get_parameter_list(device=d):
@@ -52,7 +82,7 @@ for i in interfaces:
 #  for r in get_region_list(device=d):
 #    for gn in get_parameter_list(device=d, region=r):
 #      print("{0} {1} {2} {3}").format(d, r, gn, get_parameter(device=d, region=r, name=gn))
-#write_devices(file="foo.msh", type="devsim")
+# write_devices(file="foo.msh", type="devsim")
 solve(type="dc", absolute_error=1.0e-13, relative_error=1e-12, maximum_iterations=30)
 solve(type="dc", absolute_error=1.0e-13, relative_error=1e-12, maximum_iterations=30)
 #
@@ -62,12 +92,14 @@ write_devices(file="gmsh_mos2d_potentialonly", type="vtk")
 for i in silicon_regions:
     CreateSolution(device, i, "Electrons")
     CreateSolution(device, i, "Holes")
-    set_node_values(device=device, region=i, name="Electrons", init_from="IntrinsicElectrons")
-    set_node_values(device=device, region=i, name="Holes",     init_from="IntrinsicHoles")
+    set_node_values(
+        device=device, region=i, name="Electrons", init_from="IntrinsicElectrons"
+    )
+    set_node_values(device=device, region=i, name="Holes", init_from="IntrinsicHoles")
 
     Set_Mobility_Parameters(device, i)
     Klaassen_Mobility(device, i)
-    #use bulk Klaassen mobility
+    # use bulk Klaassen mobility
     CreateSiliconDriftDiffusion(device, i, "mu_bulk_e", "mu_bulk_h")
 
 for c in contacts:
@@ -76,40 +108,56 @@ for c in contacts:
     CreateSiliconDriftDiffusionAtContact(device, r, c)
 
 for r in silicon_regions:
-    node_model(device=device, region=r, name="logElectrons", equation="log(Electrons)/log(10)")
+    node_model(
+        device=device, region=r, name="logElectrons", equation="log(Electrons)/log(10)"
+    )
     CreateNormalElectricFieldFromCurrentFlow(device, r, "ElectronCurrent")
     CreateNormalElectricFieldFromCurrentFlow(device, r, "HoleCurrent")
-    Philips_Surface_Mobility(device, r, "Enormal_ElectronCurrent", "Enormal_HoleCurrent")
-    #Philips_VelocitySaturation $device $region mu_vsat_e mu_bulk_e Eparallel_ElectronCurrent vsat_e
-    Philips_VelocitySaturation(device, r, "mu_vsat_e", "mu_e_0", "Eparallel_ElectronCurrent", "vsat_e")
+    Philips_Surface_Mobility(
+        device, r, "Enormal_ElectronCurrent", "Enormal_HoleCurrent"
+    )
+    # Philips_VelocitySaturation $device $region mu_vsat_e mu_bulk_e Eparallel_ElectronCurrent vsat_e
+    Philips_VelocitySaturation(
+        device, r, "mu_vsat_e", "mu_e_0", "Eparallel_ElectronCurrent", "vsat_e"
+    )
     CreateElementModel2d(device, r, "mu_ratio", "mu_vsat_e/mu_bulk_e")
     CreateElementModel2d(device, r, "mu_surf_ratio", "mu_e_0/mu_bulk_e")
-    CreateElementModel2d(device, r, "epar_ratio", "abs(Eparallel_ElectronCurrent/ElectricField_mag)")
-    #createElementElectronCurrent2d $device $region ElementElectronCurrent mu_n
-    #createElementElectronCurrent2d $device $region ElementElectronCurrent mu_bulk_e
+    CreateElementModel2d(
+        device, r, "epar_ratio", "abs(Eparallel_ElectronCurrent/ElectricField_mag)"
+    )
+    # createElementElectronCurrent2d $device $region ElementElectronCurrent mu_n
+    # createElementElectronCurrent2d $device $region ElementElectronCurrent mu_bulk_e
     CreateElementElectronCurrent2d(device, r, "ElementElectronCurrent", "mu_vsat_e")
     # element_from_edge_model -edge_model ElectricField   -device $device -region $i
-    CreateElementModel2d(device, r, "magElementElectronCurrent", "log(abs(ElementElectronCurrent)+1e-10)/log(10)")
-    vector_element_model(device=device, region=r, element_model="ElementElectronCurrent")
+    CreateElementModel2d(
+        device,
+        r,
+        "magElementElectronCurrent",
+        "log(abs(ElementElectronCurrent)+1e-10)/log(10)",
+    )
+    vector_element_model(
+        device=device, region=r, element_model="ElementElectronCurrent"
+    )
     # we aren't going to worry about holes for now.
-    #createNormalElectricFieldFromCurrentFlow $device $region HoleCurrent
+    # createNormalElectricFieldFromCurrentFlow $device $region HoleCurrent
     CreateElementElectronContinuityEquation(device, r, "ElementElectronCurrent")
 
 for contact in ("body", "drain", "source"):
-    CreateElementContactElectronContinuityEquation(device, contact, "ElementElectronCurrent")
+    CreateElementContactElectronContinuityEquation(
+        device, contact, "ElementElectronCurrent"
+    )
 
-#write_devices(file="debug.msh", type="devsim")
+# write_devices(file="debug.msh", type="devsim")
 solve(type="dc", absolute_error=1.0e30, relative_error=1e-10, maximum_iterations=100)
 write_devices(file="gmsh_mos2d_dd_kla_zero.dat", type="tecplot")
 write_devices(file="gmsh_mos2d_dd_kla_zero", type="vtk")
 
 
-drainbias=get_parameter(device=device, name=GetContactBiasName("drain"))
-gatebias=get_parameter(device=device, name=GetContactBiasName("gate"))
+drainbias = get_parameter(device=device, name=GetContactBiasName("drain"))
+gatebias = get_parameter(device=device, name=GetContactBiasName("gate"))
 
-rampbias(device, "gate",  0.5, 0.5, 0.001, 100, 1e-8, 1e30, printAllCurrents)
+rampbias(device, "gate", 0.5, 0.5, 0.001, 100, 1e-8, 1e30, printAllCurrents)
 rampbias(device, "drain", 0.5, 0.1, 0.001, 100, 1e-8, 1e30, printAllCurrents)
 
 write_devices(file="gmsh_mos2d_dd_kla.dat", type="tecplot")
 write_devices(file="gmsh_mos2d_dd_kla", type="vtk")
-

--- a/examples/mobility/pythonmesh2d.py
+++ b/examples/mobility/pythonmesh2d.py
@@ -1,44 +1,100 @@
-from devsim import add_gmsh_contact, add_gmsh_interface, add_gmsh_region, create_device, create_gmsh_mesh, finalize_mesh, write_devices
+from devsim import (
+    add_gmsh_contact,
+    add_gmsh_interface,
+    add_gmsh_region,
+    create_device,
+    create_gmsh_mesh,
+    finalize_mesh,
+    write_devices,
+)
 
 import devsim.python_packages.pythonmesh
 
-def gmsh_reader(mesh, device, filename="", coordinates="", physical_names="", elements=""):
-    if (filename):
+
+def gmsh_reader(
+    mesh, device, filename="", coordinates="", physical_names="", elements=""
+):
+    if filename:
         create_gmsh_mesh(file=filename, mesh=mesh)
     else:
-        create_gmsh_mesh(mesh=mesh, coordinates=coordinates, physical_names=physical_names, elements=elements)
-    add_gmsh_region    (mesh=mesh, gmsh_name="bulk",    region="bulk", material="Silicon")
-    add_gmsh_region    (mesh=mesh, gmsh_name="oxide",    region="oxide", material="Silicon")
-    add_gmsh_region    (mesh=mesh, gmsh_name="gate",    region="gate", material="Silicon")
-    add_gmsh_contact   (mesh=mesh, gmsh_name="drain_contact",  region="bulk", name="drain", material="metal")
-    add_gmsh_contact   (mesh=mesh, gmsh_name="source_contact", region="bulk", name="source", material="metal")
-    add_gmsh_contact   (mesh=mesh, gmsh_name="body_contact",   region="bulk", name="body", material="metal")
-    add_gmsh_contact   (mesh=mesh, gmsh_name="gate_contact",   region="gate", name="gate", material="metal")
-    add_gmsh_interface (mesh=mesh, gmsh_name="gate_oxide_interface", region0="gate", region1="oxide", name="gate_oxide")
-    add_gmsh_interface (mesh=mesh, gmsh_name="bulk_oxide_interface", region0="bulk", region1="oxide", name="bulk_oxide")
+        create_gmsh_mesh(
+            mesh=mesh,
+            coordinates=coordinates,
+            physical_names=physical_names,
+            elements=elements,
+        )
+    add_gmsh_region(mesh=mesh, gmsh_name="bulk", region="bulk", material="Silicon")
+    add_gmsh_region(mesh=mesh, gmsh_name="oxide", region="oxide", material="Silicon")
+    add_gmsh_region(mesh=mesh, gmsh_name="gate", region="gate", material="Silicon")
+    add_gmsh_contact(
+        mesh=mesh,
+        gmsh_name="drain_contact",
+        region="bulk",
+        name="drain",
+        material="metal",
+    )
+    add_gmsh_contact(
+        mesh=mesh,
+        gmsh_name="source_contact",
+        region="bulk",
+        name="source",
+        material="metal",
+    )
+    add_gmsh_contact(
+        mesh=mesh,
+        gmsh_name="body_contact",
+        region="bulk",
+        name="body",
+        material="metal",
+    )
+    add_gmsh_contact(
+        mesh=mesh,
+        gmsh_name="gate_contact",
+        region="gate",
+        name="gate",
+        material="metal",
+    )
+    add_gmsh_interface(
+        mesh=mesh,
+        gmsh_name="gate_oxide_interface",
+        region0="gate",
+        region1="oxide",
+        name="gate_oxide",
+    )
+    add_gmsh_interface(
+        mesh=mesh,
+        gmsh_name="bulk_oxide_interface",
+        region0="bulk",
+        region1="oxide",
+        name="bulk_oxide",
+    )
     finalize_mesh(mesh=mesh)
     create_device(mesh=mesh, device=device)
 
-data = devsim.python_packages.pythonmesh.read_gmsh_file("gmsh_mos2d.msh")
-coordinates=data['coordinates']
-elements=data['elements']
-physical_names=data['physical_names']
 
-gmsh_reader(mesh="mos2da", device="mos2da", coordinates=coordinates, physical_names=physical_names, elements=elements)
+data = devsim.python_packages.pythonmesh.read_gmsh_file("gmsh_mos2d.msh")
+coordinates = data["coordinates"]
+elements = data["elements"]
+physical_names = data["physical_names"]
+
+gmsh_reader(
+    mesh="mos2da",
+    device="mos2da",
+    coordinates=coordinates,
+    physical_names=physical_names,
+    elements=elements,
+)
 gmsh_reader(mesh="mos2db", device="mos2db", filename="gmsh_mos2d.msh")
 
 write_devices(device="mos2da", file="mos2da.msh")
 write_devices(device="mos2db", file="mos2db.msh")
 
-with open('mos2da.msh', 'r') as f:
+with open("mos2da.msh", "r") as f:
     file1 = f.read()
-with open('mos2db.msh', 'r') as f:
+with open("mos2db.msh", "r") as f:
     file2 = f.read()
 
-file2=file2.replace('mos2db', 'mos2da')
+file2 = file2.replace("mos2db", "mos2da")
 
-if (file1 != file2):
-    raise RuntimeError('mos2da.msh and mos2db.msh do not match')
-
-
-
+if file1 != file2:
+    raise RuntimeError("mos2da.msh and mos2db.msh do not match")

--- a/examples/vectorpotential/twowire.py
+++ b/examples/vectorpotential/twowire.py
@@ -2,80 +2,176 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from devsim import add_gmsh_contact, add_gmsh_interface, add_gmsh_region, contact_equation, contact_node_model, create_device, create_gmsh_mesh, edge_from_node_model, edge_model, equation, finalize_mesh, get_element_model_values, get_node_model_values, interface_equation, interface_model, node_model, node_solution, set_parameter, solve, vector_gradient, write_devices
+from devsim import (
+    add_gmsh_contact,
+    add_gmsh_interface,
+    add_gmsh_region,
+    contact_equation,
+    contact_node_model,
+    create_device,
+    create_gmsh_mesh,
+    edge_from_node_model,
+    edge_model,
+    equation,
+    finalize_mesh,
+    get_element_model_values,
+    get_node_model_values,
+    interface_equation,
+    interface_model,
+    node_model,
+    node_solution,
+    set_parameter,
+    solve,
+    vector_gradient,
+    write_devices,
+)
 
-device="twowire"
+device = "twowire"
 
 create_gmsh_mesh(file="twowire.msh", mesh="twowire")
 add_gmsh_region(mesh="twowire", gmsh_name="air", region="air", material="air")
 add_gmsh_region(mesh="twowire", gmsh_name="left", region="left", material="iron")
 add_gmsh_region(mesh="twowire", gmsh_name="right", region="right", material="iron")
-add_gmsh_contact(mesh="twowire", gmsh_name="bottom", region="air", material="metal", name="bottom")
-add_gmsh_interface(mesh="twowire", gmsh_name="air_left_interface",  region0="air", region1="left" , name="air_left")
-add_gmsh_interface(mesh="twowire", gmsh_name="air_right_interface", region0="air", region1="right", name="air_right")
+add_gmsh_contact(
+    mesh="twowire", gmsh_name="bottom", region="air", material="metal", name="bottom"
+)
+add_gmsh_interface(
+    mesh="twowire",
+    gmsh_name="air_left_interface",
+    region0="air",
+    region1="left",
+    name="air_left",
+)
+add_gmsh_interface(
+    mesh="twowire",
+    gmsh_name="air_right_interface",
+    region0="air",
+    region1="right",
+    name="air_right",
+)
 finalize_mesh(mesh="twowire")
 create_device(mesh="twowire", device=device)
 
-set_parameter(device=device, region="air",   name="mu", value=1)
-set_parameter(device=device, region="left",  name="mu", value=1)
+set_parameter(device=device, region="air", name="mu", value=1)
+set_parameter(device=device, region="left", name="mu", value=1)
 set_parameter(device=device, region="right", name="mu", value=1)
 
-set_parameter(device=device, region="air",   name="jz", value=0)
-set_parameter(device=device, region="left",  name="jz", value=1)
+set_parameter(device=device, region="air", name="jz", value=0)
+set_parameter(device=device, region="left", name="jz", value=1)
 set_parameter(device=device, region="right", name="jz", value=-1)
 
 for region in ("air", "left", "right"):
     node_solution(device=device, region=region, name="Az")
     edge_from_node_model(device=device, region=region, node_model="Az")
 
-    edge_model(device=device, region=region, name="delAz",
-               equation="(Az@n1 - Az@n0) * EdgeInverseLength")
+    edge_model(
+        device=device,
+        region=region,
+        name="delAz",
+        equation="(Az@n1 - Az@n0) * EdgeInverseLength",
+    )
 
-    edge_model( device=device, region=region, name="delAz:Az@n1",
-                equation="EdgeInverseLength")
+    edge_model(
+        device=device, region=region, name="delAz:Az@n1", equation="EdgeInverseLength"
+    )
 
-    edge_model( device=device, region=region, name="delAz:Az@n0",
-                equation="-EdgeInverseLength")
+    edge_model(
+        device=device, region=region, name="delAz:Az@n0", equation="-EdgeInverseLength"
+    )
 
-    node_model( device=device, region=region, name="Jz",
-                equation="mu * jz")
+    node_model(device=device, region=region, name="Jz", equation="mu * jz")
 
-    equation(device=device, region=region, name="Az_Equation",
-             variable_name="Az", edge_model="delAz", node_model="Jz")
-
+    equation(
+        device=device,
+        region=region,
+        name="Az_Equation",
+        variable_name="Az",
+        edge_model="delAz",
+        node_model="Jz",
+    )
 
     vector_gradient(device=device, region=region, node_model="Az", calc_type="default")
 
-    node_model( device=device, region=region, name="Bx", equation="Az_grady")
-    node_model( device=device, region=region, name="By", equation="-Az_gradx")
+    node_model(device=device, region=region, name="Bx", equation="Az_grady")
+    node_model(device=device, region=region, name="By", equation="-Az_gradx")
 
 #### interfaces
 for interface in ("air_left", "air_right"):
-    interface_model( device=device, interface=interface, name="continuousAz",       equation="Az@r0 - Az@r1")
-    interface_model( device=device, interface=interface, name="continuousAz:Az@r0", equation="1.0")
-    interface_model( device=device, interface=interface, name="continuousAz:Az@r1", equation="-1.0")
+    interface_model(
+        device=device,
+        interface=interface,
+        name="continuousAz",
+        equation="Az@r0 - Az@r1",
+    )
+    interface_model(
+        device=device, interface=interface, name="continuousAz:Az@r0", equation="1.0"
+    )
+    interface_model(
+        device=device, interface=interface, name="continuousAz:Az@r1", equation="-1.0"
+    )
 
-    interface_equation(device=device, interface=interface,  name="Az_Equation",
-                       interface_model="continuousAz", type="continuous")
+    interface_equation(
+        device=device,
+        interface=interface,
+        name="Az_Equation",
+        interface_model="continuousAz",
+        type="continuous",
+    )
 
 
 #### contact
-contact_node_model(device=device, contact="bottom", name="Az_zero",    equation="Az - 0")
+contact_node_model(device=device, contact="bottom", name="Az_zero", equation="Az - 0")
 contact_node_model(device=device, contact="bottom", name="Az_zero:Az", equation="1.0")
-contact_equation(device=device, contact="bottom", name="Az_Equation",
-                 node_model="Az_zero")
+contact_equation(
+    device=device, contact="bottom", name="Az_Equation", node_model="Az_zero"
+)
 
-#write_devices(file="debug.msh")
+# write_devices(file="debug.msh")
 
 solve(relative_error=1e-10, absolute_error=1, type="dc")
 
 write_devices(file="gmsh_{0}_out.msh".format(device))
 write_devices(file="gmsh_{0}_out.dat".format(device), type="tecplot")
 
-print("ElementNodeVolume {0:e}".format(sum(get_element_model_values(device=device, region="air", name="ElementNodeVolume"))))
-print("NodeVolume {0:e}".format(sum(get_node_model_values(device=device, region="air", name="NodeVolume"))))
-print("ElementNodeVolume {0:e}".format(sum(get_element_model_values(device=device, region="left", name="ElementNodeVolume"))))
-print("NodeVolume {0:e}".format(sum(get_node_model_values(device=device, region="left", name="NodeVolume"))))
-print("ElementNodeVolume {0:e}".format(sum(get_element_model_values(device=device, region="right", name="ElementNodeVolume"))))
-print("NodeVolume {0:e}".format(sum(get_node_model_values(device=device, region="right", name="NodeVolume"))))
-
+print(
+    "ElementNodeVolume {0:e}".format(
+        sum(
+            get_element_model_values(
+                device=device, region="air", name="ElementNodeVolume"
+            )
+        )
+    )
+)
+print(
+    "NodeVolume {0:e}".format(
+        sum(get_node_model_values(device=device, region="air", name="NodeVolume"))
+    )
+)
+print(
+    "ElementNodeVolume {0:e}".format(
+        sum(
+            get_element_model_values(
+                device=device, region="left", name="ElementNodeVolume"
+            )
+        )
+    )
+)
+print(
+    "NodeVolume {0:e}".format(
+        sum(get_node_model_values(device=device, region="left", name="NodeVolume"))
+    )
+)
+print(
+    "ElementNodeVolume {0:e}".format(
+        sum(
+            get_element_model_values(
+                device=device, region="right", name="ElementNodeVolume"
+            )
+        )
+    )
+)
+print(
+    "NodeVolume {0:e}".format(
+        sum(get_node_model_values(device=device, region="right", name="NodeVolume"))
+    )
+)

--- a/install.py
+++ b/install.py
@@ -1,111 +1,111 @@
 import platform
-from ctypes import *
+from ctypes import *  # noqa: F403
 import sys
 import os
 import site
 
+
 class DevsimCheck:
     def check_devsim(self):
-        mkl_found = {}
+        _mkl_found = {}
         dir_path = os.path.dirname(os.path.realpath(__file__))
         dir_name = os.path.split(dir_path)[-1]
-        pieces = dir_name.split('_')
-        if len(pieces) != 3 or pieces[0] != 'devsim':
+        pieces = dir_name.split("_")
+        if len(pieces) != 3 or pieces[0] != "devsim":
             raise RuntimeError("This script needs to be run from a devsim directory")
         ret = {
-            'dir_path' : dir_path,
-            'dir_name' : dir_name,
-            'build_type' : pieces[1],
-            'version' : pieces[2]
+            "dir_path": dir_path,
+            "dir_name": dir_name,
+            "build_type": pieces[1],
+            "version": pieces[2],
         }
         return ret
 
-#    def find_mkl(self):
-#        mkl_found = {}
-#        DLL_NAMES = {
-#            'Darwin' : {'mkl' : 'libmkl_rt.1.dylib'},
-#            'Linux' : {'mkl' : 'libmkl_rt.so.1'},
-#            'Windows' : {'mkl' : 'mkl_rt.1.dll'},
-#        }
-#        mkl_found['mkl_loaded'] = False
-#        try:
-#            mydll = cdll.LoadLibrary(DLL_NAMES[self.osname]['mkl'])
-#            mkl_found['mkl_loaded'] = True
-#            print('''
-#INFO: Intel MKL %s loaded successfully
-#''' % DLL_NAMES[self.osname]['mkl'])
-#        except:
-#            print('''
-#ERROR: Intel MKL %s could not be dynamically loaded.
-#ERROR: If you are using Anaconda/Miniconda, please issue this command:
-#ERROR: conda install numpy mkl
-#ERROR:
-#ERROR: Please note that the MKL shared library is now versioned, so please ensure
-#ERROR: The exact file name is available in your installation.
-#''' % (DLL_NAMES[self.osname]['mkl'],))
-#
-#
-#        mkl_found['has_conda_mkl'] = False
-#        if self.conda['is_conda']:
-#            if self.osname == 'Windows':
-#                cpath = os.path.join(self.conda['CONDA_PREFIX'], 'Library', 'bin', DLL_NAMES[self.osname]['mkl'])
-#            else:
-#                cpath = os.path.join(self.conda['CONDA_PREFIX'], 'lib', DLL_NAMES[self.osname]['mkl'])
-#            if not os.path.exists(cpath):
-#                print('''ERROR: %s not found in CONDA_PREFIX''' % DLL_NAMES[self.osname]['mkl'])
-#                if mkl_found['mkl_loaded']:
-#                    print('''ERROR: This could mean that the Intel MKL may be loaded from somewhere else on your system.
-#''')
-#                mkl_found['has_conda_mkl'] = False
-#            else:
-#                mkl_found['has_conda_mkl'] = True
-#        return mkl_found
-#
-#
-#    def find_vcruntime(self):
-#        vcruntime_found = False
-#        try:
-#            mydll = cdll.LoadLibrary('MSVCP140.DLL')
-#            vcruntime_found = True
-#            print('''
-#INFO: Visual Studio 2019 C++ Redistributable loaded successfully
-#''' % DLL_NAMES[self.osname]['mkl'])
-#        except:
-#            print('''
-#ERROR: Visual Studio 2019 C++ redistributable could not be loaded.
-#ERROR: Please download and install from here:
-#ERROR: https://visualstudio.microsoft.com/downloads/
-#ERROR: https://aka.ms/vs/16/release/VC_redist.x64.exe
-#''')
-#        return vcruntime_found
-#
-#    def check_conda(self):
-#        ret = {
-#            'is_conda' : os.path.exists(os.path.join(sys.base_prefix, 'conda-meta'))
-#        }
-#
-#        if 'CONDA_PREFIX' in os.environ:
-#            ret['CONDA_PREFIX'] = os.environ['CONDA_PREFIX']
-#            if self.python['site-packages'].find(ret['CONDA_PREFIX']) != 0:
-#                RuntimeError("site-packages not found as a subdirectory of CONDA_PREFIX")
-#        return ret
+    #    def find_mkl(self):
+    #        mkl_found = {}
+    #        DLL_NAMES = {
+    #            'Darwin' : {'mkl' : 'libmkl_rt.1.dylib'},
+    #            'Linux' : {'mkl' : 'libmkl_rt.so.1'},
+    #            'Windows' : {'mkl' : 'mkl_rt.1.dll'},
+    #        }
+    #        mkl_found['mkl_loaded'] = False
+    #        try:
+    #            mydll = cdll.LoadLibrary(DLL_NAMES[self.osname]['mkl'])
+    #            mkl_found['mkl_loaded'] = True
+    #            print('''
+    # INFO: Intel MKL %s loaded successfully
+    #''' % DLL_NAMES[self.osname]['mkl'])
+    #        except:
+    #            print('''
+    # ERROR: Intel MKL %s could not be dynamically loaded.
+    # ERROR: If you are using Anaconda/Miniconda, please issue this command:
+    # ERROR: conda install numpy mkl
+    # ERROR:
+    # ERROR: Please note that the MKL shared library is now versioned, so please ensure
+    # ERROR: The exact file name is available in your installation.
+    #''' % (DLL_NAMES[self.osname]['mkl'],))
+    #
+    #
+    #        mkl_found['has_conda_mkl'] = False
+    #        if self.conda['is_conda']:
+    #            if self.osname == 'Windows':
+    #                cpath = os.path.join(self.conda['CONDA_PREFIX'], 'Library', 'bin', DLL_NAMES[self.osname]['mkl'])
+    #            else:
+    #                cpath = os.path.join(self.conda['CONDA_PREFIX'], 'lib', DLL_NAMES[self.osname]['mkl'])
+    #            if not os.path.exists(cpath):
+    #                print('''ERROR: %s not found in CONDA_PREFIX''' % DLL_NAMES[self.osname]['mkl'])
+    #                if mkl_found['mkl_loaded']:
+    #                    print('''ERROR: This could mean that the Intel MKL may be loaded from somewhere else on your system.
+    #''')
+    #                mkl_found['has_conda_mkl'] = False
+    #            else:
+    #                mkl_found['has_conda_mkl'] = True
+    #        return mkl_found
+    #
+    #
+    #    def find_vcruntime(self):
+    #        vcruntime_found = False
+    #        try:
+    #            mydll = cdll.LoadLibrary('MSVCP140.DLL')
+    #            vcruntime_found = True
+    #            print('''
+    # INFO: Visual Studio 2019 C++ Redistributable loaded successfully
+    #''' % DLL_NAMES[self.osname]['mkl'])
+    #        except:
+    #            print('''
+    # ERROR: Visual Studio 2019 C++ redistributable could not be loaded.
+    # ERROR: Please download and install from here:
+    # ERROR: https://visualstudio.microsoft.com/downloads/
+    # ERROR: https://aka.ms/vs/16/release/VC_redist.x64.exe
+    #''')
+    #        return vcruntime_found
+    #
+    #    def check_conda(self):
+    #        ret = {
+    #            'is_conda' : os.path.exists(os.path.join(sys.base_prefix, 'conda-meta'))
+    #        }
+    #
+    #        if 'CONDA_PREFIX' in os.environ:
+    #            ret['CONDA_PREFIX'] = os.environ['CONDA_PREFIX']
+    #            if self.python['site-packages'].find(ret['CONDA_PREFIX']) != 0:
+    #                RuntimeError("site-packages not found as a subdirectory of CONDA_PREFIX")
+    #        return ret
 
     def check_python(self):
         ret = {}
         try:
-            ppath = os.environ['PYTHONPATH']
-        except:
+            ppath = os.environ["PYTHONPATH"]
+        except Exception:
             ppath = None
-        ret = {
-          'PYTHONPATH' : ppath}
+        ret = {"PYTHONPATH": ppath}
 
-        for s in ('USER_BASE', 'USER_SITE', 'ENABLE_USER_SITE'):
+        for s in ("USER_BASE", "USER_SITE", "ENABLE_USER_SITE"):
             ret[s] = site.__dict__[s]
 
-        ret['site-packages'] = None
+        ret["site-packages"] = None
         for s in sys.path:
-            if os.path.split(s)[-1] == 'site-packages':
-                ret['site-packages'] = s
+            if os.path.split(s)[-1] == "site-packages":
+                ret["site-packages"] = s
                 break
 
         print("Python Version " + ".".join([str(x) for x in sys.version_info[0:3]]))
@@ -115,7 +115,7 @@ class DevsimCheck:
         return ret
 
     def install_link(self):
-        setup_py='''#!/usr/bin/env python
+        setup_py = """#!/usr/bin/env python
 
 from distutils.core import setup
 #https://docs.python.org/3/distutils/setupscript.html
@@ -128,45 +128,43 @@ setup(name='devsim',
       license='Apache-2.0',
       packages=['devsim', 'symdiff'],
 )
-''' % self.devsim['version']
-        ofile = os.path.join(self.devsim['dir_path'], 'lib', 'setup.py')
-        print('''
+""" % self.devsim["version"]
+        ofile = os.path.join(self.devsim["dir_path"], "lib", "setup.py")
+        print(
+            """
 INFO: Writing %s
-INFO:''' % ofile)
-        with open(ofile, 'w') as of:
-          of.write(setup_py)
+INFO:"""
+            % ofile
+        )
+        with open(ofile, "w") as of:
+            of.write(setup_py)
 
-
-        print('''\
+        print("""\
 INFO: Please type the following command to install devsim:
 INFO: pip install -e lib
 INFO:
 INFO: To remove the file, type:
 INFO: pip uninstall devsim
-''')
+""")
 
     def __init__(self):
         self.osname = platform.system()
         self.devsim = self.check_devsim()
-#        self.vcruntime = None
-#        if self.devsim['build_type'] == 'win64':
-#            self.vcruntime = self.find_vcruntime()
-        self.python= self.check_python()
+        #        self.vcruntime = None
+        #        if self.devsim['build_type'] == 'win64':
+        #            self.vcruntime = self.find_vcruntime()
+        self.python = self.check_python()
+
+
 #        self.conda = self.check_conda()
 #        self.mkl = self.find_mkl()
 
 
-
 if __name__ == "__main__":
-# check version 3, 64 bit etc, msys
+    # check version 3, 64 bit etc, msys
     dc = DevsimCheck()
-#    if not dc.conda['is_conda']:
-#        raise RuntimeError("Currently installation from a conda environment is the only one supported")
-#    if not dc.mkl['has_conda_mkl']:
-#        raise RuntimeError("ERROR MKL NOT FOUND")
+    #    if not dc.conda['is_conda']:
+    #        raise RuntimeError("Currently installation from a conda environment is the only one supported")
+    #    if not dc.mkl['has_conda_mkl']:
+    #        raise RuntimeError("ERROR MKL NOT FOUND")
     dc.install_link()
-
-
-
-
-

--- a/python_packages/Klaassen.py
+++ b/python_packages/Klaassen.py
@@ -4,33 +4,41 @@
 
 from devsim import set_parameter
 
-from devsim.python_packages.model_create import CreateNodeModel, CreateNodeModelDerivative, CreateEdgeModel, CreateElementModel2d, CreateElementModelDerivative2d, CreateGeometricMean, CreateGeometricMeanDerivative
+from devsim.python_packages.model_create import (
+    CreateNodeModel,
+    CreateNodeModelDerivative,
+    CreateEdgeModel,
+    CreateElementModel2d,
+    CreateElementModelDerivative2d,
+    CreateGeometricMean,
+    CreateGeometricMeanDerivative,
+)
+
 
 def Set_Mobility_Parameters(device, region):
-    #As
-    set_parameter(device=device, region=region, name="mu_min_e",  value=52.2)
-    set_parameter(device=device, region=region, name="mu_max_e",  value=1417)
-    set_parameter(device=device, region=region, name="theta1_e",     value=2.285)
-    set_parameter(device=device, region=region, name="m_e",      value=1.0)
-    set_parameter(device=device, region=region, name="f_BH",     value=3.828)
-    set_parameter(device=device, region=region, name="f_CW",     value=2.459)
-    set_parameter(device=device, region=region, name="c_D",      value=0.21)
-    set_parameter(device=device, region=region, name="Nref_D",   value=4.0e20)
+    # As
+    set_parameter(device=device, region=region, name="mu_min_e", value=52.2)
+    set_parameter(device=device, region=region, name="mu_max_e", value=1417)
+    set_parameter(device=device, region=region, name="theta1_e", value=2.285)
+    set_parameter(device=device, region=region, name="m_e", value=1.0)
+    set_parameter(device=device, region=region, name="f_BH", value=3.828)
+    set_parameter(device=device, region=region, name="f_CW", value=2.459)
+    set_parameter(device=device, region=region, name="c_D", value=0.21)
+    set_parameter(device=device, region=region, name="Nref_D", value=4.0e20)
     set_parameter(device=device, region=region, name="Nref_1_e", value=9.68e16)
-    set_parameter(device=device, region=region, name="alpha_1_e",    value=0.68)
+    set_parameter(device=device, region=region, name="alpha_1_e", value=0.68)
 
-    #B
-    set_parameter(device=device, region=region, name="mu_min_h",  value=44.9)
-    set_parameter(device=device, region=region, name="mu_max_h",  value=470.5)
-    set_parameter(device=device, region=region, name="theta1_h",     value=2.247)
-    set_parameter(device=device, region=region, name="m_h",      value=1.258)
-    set_parameter(device=device, region=region, name="c_A",      value=0.50)
-    set_parameter(device=device, region=region, name="Nref_A",   value=7.2e20)
+    # B
+    set_parameter(device=device, region=region, name="mu_min_h", value=44.9)
+    set_parameter(device=device, region=region, name="mu_max_h", value=470.5)
+    set_parameter(device=device, region=region, name="theta1_h", value=2.247)
+    set_parameter(device=device, region=region, name="m_h", value=1.258)
+    set_parameter(device=device, region=region, name="c_A", value=0.50)
+    set_parameter(device=device, region=region, name="Nref_A", value=7.2e20)
     set_parameter(device=device, region=region, name="Nref_1_h", value=2.2e17)
-    set_parameter(device=device, region=region, name="alpha_1_h",    value=0.719)
+    set_parameter(device=device, region=region, name="alpha_1_h", value=0.719)
 
-
-    #F_Pe F_Ph equations
+    # F_Pe F_Ph equations
     set_parameter(device=device, region=region, name="r1", value=0.7643)
     set_parameter(device=device, region=region, name="r2", value=2.2999)
     set_parameter(device=device, region=region, name="r3", value=6.5502)
@@ -38,7 +46,7 @@ def Set_Mobility_Parameters(device, region):
     set_parameter(device=device, region=region, name="r5", value=-0.01552)
     set_parameter(device=device, region=region, name="r6", value=0.6478)
 
-    #G_Pe G_Ph equations
+    # G_Pe G_Ph equations
     set_parameter(device=device, region=region, name="s1", value=0.892333)
     set_parameter(device=device, region=region, name="s2", value=0.41372)
     set_parameter(device=device, region=region, name="s3", value=0.19778)
@@ -51,7 +59,7 @@ def Set_Mobility_Parameters(device, region):
     set_parameter(device=device, region=region, name="vsat_e", value=1.0e7)
     set_parameter(device=device, region=region, name="vsat_h", value=1.0e7)
 
-    #Lucent Mobility
+    # Lucent Mobility
     set_parameter(device=device, region=region, name="alpha_e", value=6.85e-21)
     set_parameter(device=device, region=region, name="alpha_h", value=7.82e-21)
     set_parameter(device=device, region=region, name="A_e", value=2.58)
@@ -69,203 +77,260 @@ def Set_Mobility_Parameters(device, region):
     set_parameter(device=device, region=region, name="delta_e", value=3.58e18)
     set_parameter(device=device, region=region, name="delta_h", value=4.10e15)
 
-#mobility_h="(Electrons@n0*Electrons@n1)^(0.5)"
-#mobility_e="(Holes@n0*Holes@n1)^(0.5)"
 
-#assumption is we will substitute As or P as appropriate
-#remember the derivatives as well
+# mobility_h="(Electrons@n0*Electrons@n1)^(0.5)"
+# mobility_e="(Holes@n0*Holes@n1)^(0.5)"
+
+
+# assumption is we will substitute As or P as appropriate
+# remember the derivatives as well
 ### This is the Klaassen mobility, need to adapt to Darwish
 def Klaassen_Mobility(device, region):
     # require Electrons, Holes, Donors, Acceptors already exist
-    mu_L_e="(mu_max_e * (300 / T)^theta1_e)"
-    mu_L_h="(mu_max_h * (300 / T)^theta1_h)"
+    mu_L_e = "(mu_max_e * (300 / T)^theta1_e)"
+    mu_L_h = "(mu_max_h * (300 / T)^theta1_h)"
     CreateNodeModel(device, region, "mu_L_e", mu_L_e)
     CreateNodeModel(device, region, "mu_L_h", mu_L_h)
 
-    mu_e_N="(mu_max_e * mu_max_e / (mu_max_e - mu_min_e) * (T/300)^(3*alpha_1_e - 1.5))"
-    mu_h_N="(mu_max_h * mu_max_h / (mu_max_h - mu_min_h) * (T/300)^(3*alpha_1_h - 1.5))"
+    mu_e_N = (
+        "(mu_max_e * mu_max_e / (mu_max_e - mu_min_e) * (T/300)^(3*alpha_1_e - 1.5))"
+    )
+    mu_h_N = (
+        "(mu_max_h * mu_max_h / (mu_max_h - mu_min_h) * (T/300)^(3*alpha_1_h - 1.5))"
+    )
     CreateNodeModel(device, region, "mu_e_N", mu_e_N)
     CreateNodeModel(device, region, "mu_h_N", mu_h_N)
 
-    mu_e_c="(mu_min_e * mu_max_e / (mu_max_e - mu_min_e)) * (300/T)^(0.5)"
-    mu_h_c="(mu_min_h * mu_max_h / (mu_max_h - mu_min_h)) * (300/T)^(0.5)"
+    mu_e_c = "(mu_min_e * mu_max_e / (mu_max_e - mu_min_e)) * (300/T)^(0.5)"
+    mu_h_c = "(mu_min_h * mu_max_h / (mu_max_h - mu_min_h)) * (300/T)^(0.5)"
     CreateNodeModel(device, region, "mu_e_c", mu_e_c)
     CreateNodeModel(device, region, "mu_h_c", mu_h_c)
 
-    PBH_e="(1.36e20/(Electrons + Holes) * (m_e) * (T/300)^2)"
-    PBH_h="(1.36e20/(Electrons + Holes) * (m_h) * (T/300)^2)"
-    CreateNodeModel (device,  region, "PBH_e", PBH_e)
+    PBH_e = "(1.36e20/(Electrons + Holes) * (m_e) * (T/300)^2)"
+    PBH_h = "(1.36e20/(Electrons + Holes) * (m_h) * (T/300)^2)"
+    CreateNodeModel(device, region, "PBH_e", PBH_e)
     CreateNodeModelDerivative(device, region, "PBH_e", PBH_e, "Electrons", "Holes")
-    CreateNodeModel (device,  region, "PBH_h", PBH_h)
+    CreateNodeModel(device, region, "PBH_h", PBH_h)
     CreateNodeModelDerivative(device, region, "PBH_h", PBH_h, "Electrons", "Holes")
 
-    Z_D="(1 + 1 / (c_D + (Nref_D / Donors)^2))"
-    Z_A="(1 + 1 / (c_A + (Nref_A / Acceptors)^2))"
-    CreateNodeModel (device, region, "Z_D", Z_D)
-    CreateNodeModel (device, region, "Z_A", Z_A)
+    Z_D = "(1 + 1 / (c_D + (Nref_D / Donors)^2))"
+    Z_A = "(1 + 1 / (c_A + (Nref_A / Acceptors)^2))"
+    CreateNodeModel(device, region, "Z_D", Z_D)
+    CreateNodeModel(device, region, "Z_A", Z_A)
 
-    N_D="(Z_D * Donors)"
-    N_A="(Z_A * Acceptors)"
-    CreateNodeModel (device,  region, "N_D", N_D)
-    CreateNodeModel (device,  region, "N_A", N_A)
+    N_D = "(Z_D * Donors)"
+    N_A = "(Z_A * Acceptors)"
+    CreateNodeModel(device, region, "N_D", N_D)
+    CreateNodeModel(device, region, "N_A", N_A)
 
-    N_e_sc="(N_D + N_A + Holes)"
-    N_h_sc="(N_A + N_D + Electrons)"
-    CreateNodeModel (device,  region, "N_e_sc", N_e_sc)
+    N_e_sc = "(N_D + N_A + Holes)"
+    N_h_sc = "(N_A + N_D + Electrons)"
+    CreateNodeModel(device, region, "N_e_sc", N_e_sc)
     CreateNodeModelDerivative(device, region, "N_e_sc", N_e_sc, "Electrons", "Holes")
-    CreateNodeModel (device,  region, "N_h_sc", N_h_sc)
+    CreateNodeModel(device, region, "N_h_sc", N_h_sc)
     CreateNodeModelDerivative(device, region, "N_h_sc", N_h_sc, "Electrons", "Holes")
 
-    PCW_e="(3.97e13 * (1/(Z_D^3 * N_e_sc) * (T/300)^3)^(2/3))"
-    PCW_h="(3.97e13 * (1/(Z_A^3 * N_h_sc) * (T/300)^3)^(2/3))"
+    PCW_e = "(3.97e13 * (1/(Z_D^3 * N_e_sc) * (T/300)^3)^(2/3))"
+    PCW_h = "(3.97e13 * (1/(Z_A^3 * N_h_sc) * (T/300)^3)^(2/3))"
 
-    CreateNodeModel (device,  region, "PCW_e", PCW_e)
+    CreateNodeModel(device, region, "PCW_e", PCW_e)
     CreateNodeModelDerivative(device, region, "PCW_e", PCW_e, "Electrons", "Holes")
-    CreateNodeModel (device,  region, "PCW_h", PCW_h)
+    CreateNodeModel(device, region, "PCW_h", PCW_h)
     CreateNodeModelDerivative(device, region, "PCW_h", PCW_h, "Electrons", "Holes")
 
-    Pe="(1/(f_CW / PCW_e + f_BH/PBH_e))"
-    Ph="(1/(f_CW / PCW_h + f_BH/PBH_h))"
-    CreateNodeModel (device,  region, "Pe", Pe)
+    Pe = "(1/(f_CW / PCW_e + f_BH/PBH_e))"
+    Ph = "(1/(f_CW / PCW_h + f_BH/PBH_h))"
+    CreateNodeModel(device, region, "Pe", Pe)
     CreateNodeModelDerivative(device, region, "Pe", Pe, "Electrons", "Holes")
-    CreateNodeModel (device,  region, "Ph", Ph)
+    CreateNodeModel(device, region, "Ph", Ph)
     CreateNodeModelDerivative(device, region, "Ph", Ph, "Electrons", "Holes")
 
-    G_Pe="(1 - s1 / (s2 + (1.0/m_e * T/300)^s4 * Pe)^s3 + s5/((m_e * 300/T)^s7*Pe)^s6)"
-    G_Ph="(1 - s1 / (s2 + (1.0/m_h * T/300)^s4 * Ph)^s3 + s5/((m_h * 300/T)^s7*Ph)^s6)"
+    G_Pe = (
+        "(1 - s1 / (s2 + (1.0/m_e * T/300)^s4 * Pe)^s3 + s5/((m_e * 300/T)^s7*Pe)^s6)"
+    )
+    G_Ph = (
+        "(1 - s1 / (s2 + (1.0/m_h * T/300)^s4 * Ph)^s3 + s5/((m_h * 300/T)^s7*Ph)^s6)"
+    )
 
-    CreateNodeModel (device,  region, "G_Pe", G_Pe)
+    CreateNodeModel(device, region, "G_Pe", G_Pe)
     CreateNodeModelDerivative(device, region, "G_Pe", G_Pe, "Electrons", "Holes")
-    CreateNodeModel (device,  region, "G_Ph", G_Ph)
+    CreateNodeModel(device, region, "G_Ph", G_Ph)
     CreateNodeModelDerivative(device, region, "G_Ph", G_Ph, "Electrons", "Holes")
 
-    F_Pe="((r1 * Pe^r6 + r2 + r3 * m_e/m_h)/(Pe^r6 + r4 + r5 * m_e/m_h))"
-    F_Ph="((r1 * Ph^r6 + r2 + r3 * m_h/m_e)/(Ph^r6 + r4 + r5 * m_h/m_e))"
+    F_Pe = "((r1 * Pe^r6 + r2 + r3 * m_e/m_h)/(Pe^r6 + r4 + r5 * m_e/m_h))"
+    F_Ph = "((r1 * Ph^r6 + r2 + r3 * m_h/m_e)/(Ph^r6 + r4 + r5 * m_h/m_e))"
 
-    CreateNodeModel (device,  region, "F_Pe", F_Pe)
+    CreateNodeModel(device, region, "F_Pe", F_Pe)
     CreateNodeModelDerivative(device, region, "F_Pe", F_Pe, "Electrons", "Holes")
-    CreateNodeModel (device,  region, "F_Ph", F_Ph)
+    CreateNodeModel(device, region, "F_Ph", F_Ph)
     CreateNodeModelDerivative(device, region, "F_Ph", F_Ph, "Electrons", "Holes")
 
-    N_e_sc_eff="(N_D + G_Pe * N_A + Holes / F_Pe)"
-    N_h_sc_eff="(N_A + G_Ph * N_D + Electrons / F_Ph)"
+    N_e_sc_eff = "(N_D + G_Pe * N_A + Holes / F_Pe)"
+    N_h_sc_eff = "(N_A + G_Ph * N_D + Electrons / F_Ph)"
 
-    CreateNodeModel (device,  region, "N_e_sc_eff", N_e_sc_eff)
-    CreateNodeModelDerivative(device, region, "N_e_sc_eff", N_e_sc_eff, "Electrons", "Holes")
-    CreateNodeModel (device,  region, "N_h_sc_eff", N_h_sc_eff)
-    CreateNodeModelDerivative(device, region, "N_h_sc_eff", N_h_sc_eff, "Electrons", "Holes")
+    CreateNodeModel(device, region, "N_e_sc_eff", N_e_sc_eff)
+    CreateNodeModelDerivative(
+        device, region, "N_e_sc_eff", N_e_sc_eff, "Electrons", "Holes"
+    )
+    CreateNodeModel(device, region, "N_h_sc_eff", N_h_sc_eff)
+    CreateNodeModelDerivative(
+        device, region, "N_h_sc_eff", N_h_sc_eff, "Electrons", "Holes"
+    )
 
-    mu_e_D_A_h="mu_e_N * N_e_sc/N_e_sc_eff * (Nref_1_e / N_e_sc)^alpha_1_e + mu_e_c * ((Electrons + Holes)/N_e_sc_eff)"
-    mu_h_D_A_e="mu_h_N * N_h_sc/N_h_sc_eff * (Nref_1_h / N_h_sc)^alpha_1_h + mu_h_c * ((Electrons + Holes)/N_h_sc_eff)"
+    mu_e_D_A_h = "mu_e_N * N_e_sc/N_e_sc_eff * (Nref_1_e / N_e_sc)^alpha_1_e + mu_e_c * ((Electrons + Holes)/N_e_sc_eff)"
+    mu_h_D_A_e = "mu_h_N * N_h_sc/N_h_sc_eff * (Nref_1_h / N_h_sc)^alpha_1_h + mu_h_c * ((Electrons + Holes)/N_h_sc_eff)"
 
-    CreateNodeModel          (device, region, "mu_e_D_A_h", mu_e_D_A_h)
-    CreateNodeModelDerivative(device, region, "mu_e_D_A_h", mu_e_D_A_h, "Electrons", "Holes")
+    CreateNodeModel(device, region, "mu_e_D_A_h", mu_e_D_A_h)
+    CreateNodeModelDerivative(
+        device, region, "mu_e_D_A_h", mu_e_D_A_h, "Electrons", "Holes"
+    )
 
-    CreateNodeModel          (device, region, "mu_h_D_A_e", mu_h_D_A_e)
-    CreateNodeModelDerivative(device, region, "mu_h_D_A_e", mu_h_D_A_e, "Electrons", "Holes")
+    CreateNodeModel(device, region, "mu_h_D_A_e", mu_h_D_A_e)
+    CreateNodeModelDerivative(
+        device, region, "mu_h_D_A_e", mu_h_D_A_e, "Electrons", "Holes"
+    )
 
-    mu_bulk_e_Node="mu_e_D_A_h * mu_L_e / (mu_e_D_A_h + mu_L_e)" 
-    CreateNodeModel          (device, region, "mu_bulk_e_Node", mu_bulk_e_Node)
-    CreateNodeModelDerivative(device, region, "mu_bulk_e_Node", mu_bulk_e_Node, "Electrons", "Holes")
+    mu_bulk_e_Node = "mu_e_D_A_h * mu_L_e / (mu_e_D_A_h + mu_L_e)"
+    CreateNodeModel(device, region, "mu_bulk_e_Node", mu_bulk_e_Node)
+    CreateNodeModelDerivative(
+        device, region, "mu_bulk_e_Node", mu_bulk_e_Node, "Electrons", "Holes"
+    )
 
-    mu_bulk_h_Node="mu_h_D_A_e * mu_L_h / (mu_h_D_A_e + mu_L_h)" 
-    CreateNodeModel          (device, region, "mu_bulk_h_Node", mu_bulk_h_Node)
-    CreateNodeModelDerivative(device, region, "mu_bulk_h_Node", mu_bulk_h_Node, "Electrons", "Holes")
+    mu_bulk_h_Node = "mu_h_D_A_e * mu_L_h / (mu_h_D_A_e + mu_L_h)"
+    CreateNodeModel(device, region, "mu_bulk_h_Node", mu_bulk_h_Node)
+    CreateNodeModelDerivative(
+        device, region, "mu_bulk_h_Node", mu_bulk_h_Node, "Electrons", "Holes"
+    )
 
-    CreateGeometricMean          (device, region, "mu_bulk_e_Node", "mu_bulk_e")
-    CreateGeometricMeanDerivative(device, region, "mu_bulk_e_Node", "mu_bulk_e", "Electrons", "Holes")
+    CreateGeometricMean(device, region, "mu_bulk_e_Node", "mu_bulk_e")
+    CreateGeometricMeanDerivative(
+        device, region, "mu_bulk_e_Node", "mu_bulk_e", "Electrons", "Holes"
+    )
 
-    CreateGeometricMean          (device, region, "mu_bulk_h_Node", "mu_bulk_h")
-    CreateGeometricMeanDerivative(device, region, "mu_bulk_h_Node", "mu_bulk_h", "Electrons", "Holes")
+    CreateGeometricMean(device, region, "mu_bulk_h_Node", "mu_bulk_h")
+    CreateGeometricMeanDerivative(
+        device, region, "mu_bulk_h_Node", "mu_bulk_h", "Electrons", "Holes"
+    )
+
 
 # mu_bulk is the original bulk model on the edge
 # mu_sat  is the saturation velocity model name
 # vsat is the name of the parameter for velocity saturation
 # eparallel is the name of the parallel efield model
 def Philips_VelocitySaturation(device, region, mu_sat, mu_bulk, eparallel, vsat):
-    mu="2*({mu_bulk}) / (1 + (1 + 4 * (max(0, ({mu_bulk}) * {eparallel})/{vsat})^2)^0.5)".format(mu_bulk=mu_bulk, eparallel=eparallel, vsat=vsat)
-    CreateElementModel2d           (device,  region, mu_sat, mu)
-    CreateElementModelDerivative2d (device,  region, mu_sat, mu, "Potential", "Electrons", "Holes")
+    mu = "2*({mu_bulk}) / (1 + (1 + 4 * (max(0, ({mu_bulk}) * {eparallel})/{vsat})^2)^0.5)".format(
+        mu_bulk=mu_bulk, eparallel=eparallel, vsat=vsat
+    )
+    CreateElementModel2d(device, region, mu_sat, mu)
+    CreateElementModelDerivative2d(
+        device, region, mu_sat, mu, "Potential", "Electrons", "Holes"
+    )
+
 
 #### Later on need model for temperature on edge
 #### Assumption is Enormal is a magnitude
 def Philips_Surface_Mobility(device, region, enormal_e, enormal_h):
     #### for now, we assume that temperature is an edge quantity and not variable dependent
-    T_prime_e="(T/300)^kappa_e"
-    T_prime_h="(T/300)^kappa_h"
+    T_prime_e = "(T/300)^kappa_e"
+    T_prime_h = "(T/300)^kappa_h"
     CreateEdgeModel(device, region, "T_prime_e", T_prime_e)
     CreateEdgeModel(device, region, "T_prime_h", T_prime_h)
     # no variables, only parameters
-    CreateNodeModel    (device, region, "NI_node", "(N_D + N_A)")
+    CreateNodeModel(device, region, "NI_node", "(N_D + N_A)")
     CreateGeometricMean(device, region, "NI_node", "NI")
 
-    #CreateGeometricMean(device, region, "Electrons", edgeElectrons)
-    #CreateGeometricMeanDerivative(device, region, "Electrons", edgeElectrons Electrons)
-    #CreateGeometricMean(device, region, "Holes",     edgeHoles)
-    #CreateGeometricMeanDerivative(device, region, "Holes",     edgeHoles Holes)
+    # CreateGeometricMean(device, region, "Electrons", edgeElectrons)
+    # CreateGeometricMeanDerivative(device, region, "Electrons", edgeElectrons Electrons)
+    # CreateGeometricMean(device, region, "Holes",     edgeHoles)
+    # CreateGeometricMeanDerivative(device, region, "Holes",     edgeHoles Holes)
 
     #### Need to prevent ridiculus mobilities for small Enormal
-    mu_ac_e="B_e /max({0},1e2) + (C_e * NI^tau_e * max({0},1e2)^(-1/3)) / T_prime_e".format(enormal_e)
-    mu_ac_h="B_h /max({0},1e2) + (C_h * NI^tau_h * max({0},1e2)^(-1/3)) / T_prime_h".format(enormal_h)
-    CreateElementModel2d          (device, region, "mu_ac_e", mu_ac_e)
+    mu_ac_e = (
+        "B_e /max({0},1e2) + (C_e * NI^tau_e * max({0},1e2)^(-1/3)) / T_prime_e".format(
+            enormal_e
+        )
+    )
+    mu_ac_h = (
+        "B_h /max({0},1e2) + (C_h * NI^tau_h * max({0},1e2)^(-1/3)) / T_prime_h".format(
+            enormal_h
+        )
+    )
+    CreateElementModel2d(device, region, "mu_ac_e", mu_ac_e)
     CreateElementModelDerivative2d(device, region, "mu_ac_e", mu_ac_e, "Potential")
-    CreateElementModel2d          (device, region, "mu_ac_h", mu_ac_h)
+    CreateElementModel2d(device, region, "mu_ac_h", mu_ac_h)
     CreateElementModelDerivative2d(device, region, "mu_ac_h", mu_ac_h, "Potential")
 
-    #gamma_e="A_e + alpha_e * (edgeElectrons + edgeHoles) * NI^(-eta_e)"
-    #gamma_h="A_h + alpha_h * (edgeElectrons + edgeHoles) * NI^(-eta_h)"
-    #CreateElementModel2d          (device, region, "gamma_e", gamma_e)
-    #CreateElementModelDerivative2d(device, region, "gamma_e", gamma_e Potential Electrons Holes)
-    #CreateElementModel2d          (device, region, "gamma_h", gamma_h)
-    #CreateElementModelDerivative2d(device, region, "gamma_h", gamma_h Potential Electrons Holes)
+    # gamma_e="A_e + alpha_e * (edgeElectrons + edgeHoles) * NI^(-eta_e)"
+    # gamma_h="A_h + alpha_h * (edgeElectrons + edgeHoles) * NI^(-eta_h)"
+    # CreateElementModel2d          (device, region, "gamma_e", gamma_e)
+    # CreateElementModelDerivative2d(device, region, "gamma_e", gamma_e Potential Electrons Holes)
+    # CreateElementModel2d          (device, region, "gamma_h", gamma_h)
+    # CreateElementModelDerivative2d(device, region, "gamma_h", gamma_h Potential Electrons Holes)
 
     # Hopefully a less problematic formulation
-    gamma_e="A_e + alpha_e * (Electrons + Holes) * NI_node^(-eta_e)"
-    gamma_h="A_h + alpha_h * (Electrons + Holes) * NI_node^(-eta_h)"
-    CreateNodeModel              (device, region, "gamma_e_Node", gamma_e)
-    CreateNodeModelDerivative    (device, region, "gamma_e_Node", gamma_e, "Electrons", "Holes")
-    CreateGeometricMean          (device, region, "gamma_e_Node", "gamma_e")
-    CreateGeometricMeanDerivative(device, region, "gamma_e_Node", "gamma_e", "Electrons", "Holes")
-    CreateNodeModel              (device, region, "gamma_h_Node", gamma_h)
-    CreateNodeModelDerivative    (device, region, "gamma_h_Node", gamma_h, "Electrons", "Holes")
-    CreateGeometricMean          (device, region, "gamma_h_Node", "gamma_h")
-    CreateGeometricMeanDerivative(device, region, "gamma_h_Node", "gamma_h", "Electrons", "Holes")
+    gamma_e = "A_e + alpha_e * (Electrons + Holes) * NI_node^(-eta_e)"
+    gamma_h = "A_h + alpha_h * (Electrons + Holes) * NI_node^(-eta_h)"
+    CreateNodeModel(device, region, "gamma_e_Node", gamma_e)
+    CreateNodeModelDerivative(
+        device, region, "gamma_e_Node", gamma_e, "Electrons", "Holes"
+    )
+    CreateGeometricMean(device, region, "gamma_e_Node", "gamma_e")
+    CreateGeometricMeanDerivative(
+        device, region, "gamma_e_Node", "gamma_e", "Electrons", "Holes"
+    )
+    CreateNodeModel(device, region, "gamma_h_Node", gamma_h)
+    CreateNodeModelDerivative(
+        device, region, "gamma_h_Node", gamma_h, "Electrons", "Holes"
+    )
+    CreateGeometricMean(device, region, "gamma_h_Node", "gamma_h")
+    CreateGeometricMeanDerivative(
+        device, region, "gamma_h_Node", "gamma_h", "Electrons", "Holes"
+    )
 
     #### Need to prevent ridiculus mobilities for small Enormal
-    mu_sr_e="delta_e *(max({0},1e2))^(-gamma_e)".format(enormal_e)
-    mu_sr_h="delta_h *(max({0},1e2))^(-gamma_h)".format(enormal_h)
-    #mu_sr_e="1e8"
-    #mu_sr_h="1e8"
-    CreateElementModel2d          (device, region, "mu_sr_e", mu_sr_e)
-    CreateElementModelDerivative2d(device, region, "mu_sr_e", mu_sr_e, "Potential", "Electrons", "Holes")
-    CreateElementModel2d          (device, region, "mu_sr_h", mu_sr_h)
-    CreateElementModelDerivative2d(device, region, "mu_sr_h", mu_sr_h, "Potential", "Electrons", "Holes")
+    mu_sr_e = "delta_e *(max({0},1e2))^(-gamma_e)".format(enormal_e)
+    mu_sr_h = "delta_h *(max({0},1e2))^(-gamma_h)".format(enormal_h)
+    # mu_sr_e="1e8"
+    # mu_sr_h="1e8"
+    CreateElementModel2d(device, region, "mu_sr_e", mu_sr_e)
+    CreateElementModelDerivative2d(
+        device, region, "mu_sr_e", mu_sr_e, "Potential", "Electrons", "Holes"
+    )
+    CreateElementModel2d(device, region, "mu_sr_h", mu_sr_h)
+    CreateElementModelDerivative2d(
+        device, region, "mu_sr_h", mu_sr_h, "Potential", "Electrons", "Holes"
+    )
 
-    mu_e_0="mu_bulk_e * mu_ac_e * mu_sr_e / (mu_bulk_e*mu_ac_e + mu_bulk_e*mu_sr_e + mu_ac_e*mu_sr_e)"
-    mu_h_0="mu_bulk_h * mu_ac_h * mu_sr_h / (mu_bulk_h*mu_ac_h + mu_bulk_h*mu_sr_h + mu_ac_h*mu_sr_h)"
-    CreateElementModel2d          (device, region, "mu_e_0", mu_e_0)
-    CreateElementModel2d          (device, region, "mu_h_0", mu_h_0)
+    mu_e_0 = "mu_bulk_e * mu_ac_e * mu_sr_e / (mu_bulk_e*mu_ac_e + mu_bulk_e*mu_sr_e + mu_ac_e*mu_sr_e)"
+    mu_h_0 = "mu_bulk_h * mu_ac_h * mu_sr_h / (mu_bulk_h*mu_ac_h + mu_bulk_h*mu_sr_h + mu_ac_h*mu_sr_h)"
+    CreateElementModel2d(device, region, "mu_e_0", mu_e_0)
+    CreateElementModel2d(device, region, "mu_h_0", mu_h_0)
 
     #### complicated derivation here
     for k in ("e", "h"):
         for i in ("Potential", "Electrons", "Holes"):
             for j in ("@en0", "@en1", "@en2"):
-                ex="mu_{k}_0^2 * (mu_bulk_{k}^(-2)*mu_bulk_{k}:{i}{j} + mu_ac_{k}^(-2)*mu_ac_{k}:{i}{j} + mu_sr_{k}^(-2) * mu_sr_{k}:{i}{j})".format(i=i, j=j, k=k)
-                CreateElementModel2d(device, region, "mu_{k}_0:{i}{j}".format(i=i, j=j, k=k), ex)
+                ex = "mu_{k}_0^2 * (mu_bulk_{k}^(-2)*mu_bulk_{k}:{i}{j} + mu_ac_{k}^(-2)*mu_ac_{k}:{i}{j} + mu_sr_{k}^(-2) * mu_sr_{k}:{i}{j})".format(
+                    i=i, j=j, k=k
+                )
+                CreateElementModel2d(
+                    device, region, "mu_{k}_0:{i}{j}".format(i=i, j=j, k=k), ex
+                )
 
-#CreateElementModelDerivative2d(device, region, "mu_e_0", mu_sr_e Potential Electrons Holes)
-#CreateElementModelDerivative2d(device, region, "mu_h_0", mu_sr_h Potential Electrons Holes)
+
+# CreateElementModelDerivative2d(device, region, "mu_e_0", mu_sr_e Potential Electrons Holes)
+# CreateElementModelDerivative2d(device, region, "mu_h_0", mu_sr_h Potential Electrons Holes)
 
 #### do we need to consider what happens if the j dot e in wrong direction
 #### or do we take care of this before
-#mu_e_ph="2*mu_e_0 / ((1 + (1 + 4 * (mu_e_0 * eparallel_e)^2))^(0.5))"
-#mu_h_ph="2*mu_h_0 / ((1 + (1 + 4 * (mu_h_0 * eparallel_h)^2))^(0.5))"
+# mu_e_ph="2*mu_e_0 / ((1 + (1 + 4 * (mu_e_0 * eparallel_e)^2))^(0.5))"
+# mu_h_ph="2*mu_h_0 / ((1 + (1 + 4 * (mu_h_0 * eparallel_h)^2))^(0.5))"
 
 
 ### do geometric mean so that
-#emobility = sqrt(mobility@n0 * mobility@n1)
-#emobility:mobility@n0 = emobility/mobility@n0
-#emobility:mobility@n1 = emobility/mobility@n1
+# emobility = sqrt(mobility@n0 * mobility@n1)
+# emobility:mobility@n0 = emobility/mobility@n0
+# emobility:mobility@n1 = emobility/mobility@n1
 # The @n0 means the quantity mobility:Electrons @n0, not the derivative of an node quantity by an edge quantitiy
-#emobility:Electrons@n0 = emobility:mobility@n0 * mobility:Electrons@n0
-#emobility:Electrons@n1 = emobility:mobility@n1 * mobility:Electrons@n1
+# emobility:Electrons@n0 = emobility:mobility@n0 * mobility:Electrons@n0
+# emobility:Electrons@n1 = emobility:mobility@n1 * mobility:Electrons@n1

--- a/python_packages/fermi_physics.py
+++ b/python_packages/fermi_physics.py
@@ -2,8 +2,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-#material parameter value unit description
-#constants = (
+# material parameter value unit description
+# constants = (
 #    ("global", "Permittivity",    8.85418782e-14, "F/cm^2", "Permittivity of Free Space"),
 #    ("SiO2",   "epsr",            3.9,            "",       "Relative Permittivity"),
 #    ("global", "ElectronCharge",  1.60217646e-19, "coul",   "Charge of electrons")
@@ -13,19 +13,19 @@
 #    ("Si",     "EG300",           1.12,           "eV",     "Energy gap at 300K"),
 #    ("Si",     "EG_ALPHA",        0.0,            "",       "Temperature dependence of Energy gap model"),
 #    ("Si",     "EG_BETA",         0.0,            "",       "Temperature dependence of Energy gap model"),
-#)
+# )
 #
 #####
 ##### These will become part of package
 #####
 ##### Need relation between EF and Potential
 #
-#Eta_C = "(EF - EC)/(k * T)"
-#Eta_V = "(EV - EF)/(k * T)"
+# Eta_C = "(EF - EC)/(k * T)"
+# Eta_V = "(EV - EF)/(k * T)"
 #
 #
 ##### EG MODEL from Wikipedia
-#EG(T) = EG(0) - (EG_ALPHA * T^2)/(T + EG_BETA)
-#ni(T) = (NC * NV)^0.5 * exp(-EG/(2 * k * T))
+# EG(T) = EG(0) - (EG_ALPHA * T^2)/(T + EG_BETA)
+# ni(T) = (NC * NV)^0.5 * exp(-EG/(2 * k * T))
 
 

--- a/python_packages/model_create.py
+++ b/python_packages/model_create.py
@@ -2,98 +2,172 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from devsim import contact_edge_model, contact_node_model, edge_average_model, edge_from_node_model, edge_model, element_model, get_edge_model_list, get_node_model_list, interface_model, node_model, node_solution
+from devsim import (
+    contact_edge_model,
+    contact_node_model,
+    edge_average_model,
+    edge_from_node_model,
+    edge_model,
+    element_model,
+    get_edge_model_list,
+    get_node_model_list,
+    interface_model,
+    node_model,
+    node_solution,
+)
 
 debug = False
+
+
 def CreateSolution(device, region, name):
-    '''
-      Creates solution variables
-      As well as their entries on each edge
-    '''
+    """
+    Creates solution variables
+    As well as their entries on each edge
+    """
     node_solution(name=name, device=device, region=region)
     edge_from_node_model(node_model=name, device=device, region=region)
 
+
 def CreateNodeModel(device, region, model, expression):
-    '''
-      Creates a node model
-    '''
-    result=node_model(device=device, region=region, name=model, equation=expression)
+    """
+    Creates a node model
+    """
+    result = node_model(device=device, region=region, name=model, equation=expression)
     if debug:
-        print(("NODEMODEL {d} {r} {m} \"{re}\"".format(d=device, r=region, m=model, re=result)))
+        print(
+            (
+                'NODEMODEL {d} {r} {m} "{re}"'.format(
+                    d=device, r=region, m=model, re=result
+                )
+            )
+        )
+
 
 def CreateNodeModelDerivative(device, region, model, expression, *vars):
-    '''
-      Create a node model derivative
-    '''
+    """
+    Create a node model derivative
+    """
     for v in vars:
-        CreateNodeModel(device, region,
-                        "{m}:{v}".format(m=model, v=v),
-                        "simplify(diff({e},{v}))".format(e=expression, v=v))
+        CreateNodeModel(
+            device,
+            region,
+            "{m}:{v}".format(m=model, v=v),
+            "simplify(diff({e},{v}))".format(e=expression, v=v),
+        )
 
 
 def CreateContactNodeModel(device, contact, model, expression):
-    '''
-      Creates a contact node model
-    '''
-    result=contact_node_model(device=device, contact=contact, name=model, equation=expression)
+    """
+    Creates a contact node model
+    """
+    result = contact_node_model(
+        device=device, contact=contact, name=model, equation=expression
+    )
     if debug:
-        print(("CONTACTNODEMODEL {d} {c} {m} \"{re}\"".format(d=device, c=contact, m=model, re=result)))
+        print(
+            (
+                'CONTACTNODEMODEL {d} {c} {m} "{re}"'.format(
+                    d=device, c=contact, m=model, re=result
+                )
+            )
+        )
 
 
 def CreateContactNodeModelDerivative(device, contact, model, expression, variable):
-    '''
-      Creates a contact node model derivative
-    '''
-    CreateContactNodeModel(device, contact,
-                           "{m}:{v}".format(m=model, v=variable),
-                           "simplify(diff({e}, {v}))".format(e=expression, v=variable))
+    """
+    Creates a contact node model derivative
+    """
+    CreateContactNodeModel(
+        device,
+        contact,
+        "{m}:{v}".format(m=model, v=variable),
+        "simplify(diff({e}, {v}))".format(e=expression, v=variable),
+    )
 
-def CreateEdgeModel (device, region, model, expression):
-    '''
-      Creates an edge model
-    '''
-    result=edge_model(device=device, region=region, name=model, equation=expression)
+
+def CreateEdgeModel(device, region, model, expression):
+    """
+    Creates an edge model
+    """
+    result = edge_model(device=device, region=region, name=model, equation=expression)
     if debug:
-        print("EDGEMODEL {d} {r} {m} \"{re}\"".format(d=device, r=region, m=model, re=result));
+        print(
+            'EDGEMODEL {d} {r} {m} "{re}"'.format(
+                d=device, r=region, m=model, re=result
+            )
+        )
+
 
 def CreateEdgeModelDerivatives(device, region, model, expression, variable):
-    '''
-      Creates edge model derivatives
-    '''
-    CreateEdgeModel(device, region,
-                    "{m}:{v}@n0".format(m=model, v=variable),
-                    "simplify(diff({e}, {v}@n0))".format(e=expression, v=variable))
-    CreateEdgeModel(device, region,
-                    "{m}:{v}@n1".format(m=model, v=variable),
-                    "simplify(diff({e}, {v}@n1))".format(e=expression, v=variable))
+    """
+    Creates edge model derivatives
+    """
+    CreateEdgeModel(
+        device,
+        region,
+        "{m}:{v}@n0".format(m=model, v=variable),
+        "simplify(diff({e}, {v}@n0))".format(e=expression, v=variable),
+    )
+    CreateEdgeModel(
+        device,
+        region,
+        "{m}:{v}@n1".format(m=model, v=variable),
+        "simplify(diff({e}, {v}@n1))".format(e=expression, v=variable),
+    )
+
 
 def CreateContactEdgeModel(device, contact, model, expression):
-    '''
-      Creates a contact edge model
-    '''
-    result=contact_edge_model(device=device, contact=contact, name=model, equation=expression)
+    """
+    Creates a contact edge model
+    """
+    result = contact_edge_model(
+        device=device, contact=contact, name=model, equation=expression
+    )
     if debug:
-        print(("CONTACTEDGEMODEL {d} {c} {m} \"{re}\"".format(d=device, c=contact, m=model, re=result)))
+        print(
+            (
+                'CONTACTEDGEMODEL {d} {c} {m} "{re}"'.format(
+                    d=device, c=contact, m=model, re=result
+                )
+            )
+        )
+
 
 def CreateContactEdgeModelDerivative(device, contact, model, expression, variable):
-    '''
-      Creates contact edge model derivatives with respect to variable on node
-    '''
-    CreateContactEdgeModel(device, contact, "{m}:{v}".format(m=model, v=variable), "simplify(diff({e}, {v}))".format(e=expression, v=variable))
+    """
+    Creates contact edge model derivatives with respect to variable on node
+    """
+    CreateContactEdgeModel(
+        device,
+        contact,
+        "{m}:{v}".format(m=model, v=variable),
+        "simplify(diff({e}, {v}))".format(e=expression, v=variable),
+    )
+
 
 def CreateInterfaceModel(device, interface, model, expression):
-    '''
-      Creates a interface node model
-    '''
-    result=interface_model(device=device, interface=interface, name=model, equation=expression)
+    """
+    Creates a interface node model
+    """
+    result = interface_model(
+        device=device, interface=interface, name=model, equation=expression
+    )
     if debug:
-        print(("INTERFACEMODEL {d} {i} {m} \"{re}\"".format(d=device, i=interface, m=model, re=result)))
+        print(
+            (
+                'INTERFACEMODEL {d} {i} {m} "{re}"'.format(
+                    d=device, i=interface, m=model, re=result
+                )
+            )
+        )
 
-#def CreateInterfaceModelDerivative(device, interface, model, expression, variable):
+
+# def CreateInterfaceModelDerivative(device, interface, model, expression, variable):
 #  '''
 #    Creates interface edge model derivatives with respect to variable on node
 #  '''
 #  CreateInterfaceModel(device, interface, "{m}:{v}".format(m=model, v=variable), "simplify(diff({e}, {v}))".format(e=expression, v=variable))
+
 
 def CreateContinuousInterfaceModel(device, interface, variable):
     mname = "continuous{0}".format(variable)
@@ -101,42 +175,53 @@ def CreateContinuousInterfaceModel(device, interface, variable):
     mname0 = "{0}:{1}@r0".format(mname, variable)
     mname1 = "{0}:{1}@r1".format(mname, variable)
     CreateInterfaceModel(device, interface, mname, meq)
-    CreateInterfaceModel(device, interface, mname0,  "1")
+    CreateInterfaceModel(device, interface, mname0, "1")
     CreateInterfaceModel(device, interface, mname1, "-1")
     return mname
 
 
 def InEdgeModelList(device, region, model):
-    '''
-      Checks to see if this edge model is available on device and region
-    '''
+    """
+    Checks to see if this edge model is available on device and region
+    """
     return model in get_edge_model_list(device=device, region=region)
 
+
 def InNodeModelList(device, region, model):
-    '''
-      Checks to see if this node model is available on device and region
-    '''
+    """
+    Checks to see if this node model is available on device and region
+    """
     return model in get_node_model_list(device=device, region=region)
+
 
 #### Make sure that the model exists, as well as it's node model
 def EnsureEdgeFromNodeModelExists(device, region, nodemodel):
-    '''
-      Checks if the edge models exists
-    '''
+    """
+    Checks if the edge models exists
+    """
     if not InNodeModelList(device, region, nodemodel):
         raise "{} must exist"
 
-    emlist = get_edge_model_list(device=device, region=region)
-    emtest = ("{0}@n0".format(nodemodel) and "{0}@n1".format(nodemodel))
+    _emlist = get_edge_model_list(device=device, region=region)
+    emtest = "{0}@n0".format(nodemodel) and "{0}@n1".format(nodemodel)
     if not emtest:
         if debug:
             print("INFO: Creating ${0}@n0 and ${0}@n1".format(nodemodel))
         edge_from_node_model(device=device, region=region, node_model=nodemodel)
 
+
 def CreateElementModel2d(device, region, model, expression):
-    result=element_model(device=device, region=region, name=model, equation=expression)
+    result = element_model(
+        device=device, region=region, name=model, equation=expression
+    )
     if debug:
-        print(("ELEMENTMODEL {d} {r} {m} \"{re}\"".format(d=device, r=region, m=model, re=result)))
+        print(
+            (
+                'ELEMENTMODEL {d} {r} {m} "{re}"'.format(
+                    d=device, r=region, m=model, re=result
+                )
+            )
+        )
 
 
 def CreateElementModelDerivative2d(device, region, model_name, expression, *args):
@@ -144,16 +229,34 @@ def CreateElementModelDerivative2d(device, region, model_name, expression, *args
         raise ValueError("Must specify a list of variable names")
     for i in args:
         for j in ("@en0", "@en1", "@en2"):
-            CreateElementModel2d(device, region, "{0}:{1}{2}".format(model_name, i, j), "diff({0}, {1}{2})".format(expression, i, j))
+            CreateElementModel2d(
+                device,
+                region,
+                "{0}:{1}{2}".format(model_name, i, j),
+                "diff({0}, {1}{2})".format(expression, i, j),
+            )
+
 
 ### edge_model is the name of the edge model to be created
 def CreateGeometricMean(device, region, nmodel, emodel):
-    edge_average_model(device=device, region=region, edge_model=emodel, node_model=nmodel, average_type="geometric")
+    edge_average_model(
+        device=device,
+        region=region,
+        edge_model=emodel,
+        node_model=nmodel,
+        average_type="geometric",
+    )
+
 
 def CreateGeometricMeanDerivative(device, region, nmodel, emodel, *args):
     if len(args) == 0:
         raise ValueError("Must specify a list of variable names")
     for i in args:
-        edge_average_model(device=device, region=region, edge_model=emodel, node_model=nmodel,
-                           derivative=i, average_type="geometric")
-
+        edge_average_model(
+            device=device,
+            region=region,
+            edge_model=emodel,
+            node_model=nmodel,
+            derivative=i,
+            average_type="geometric",
+        )

--- a/python_packages/mos_physics.py
+++ b/python_packages/mos_physics.py
@@ -4,25 +4,42 @@
 
 from devsim import contact_equation, element_from_edge_model, equation, get_dimension
 
-from devsim.python_packages.model_create import CreateElementModel2d, CreateElementModelDerivative2d
+from devsim.python_packages.model_create import (
+    CreateElementModel2d,
+    CreateElementModelDerivative2d,
+)
+
 
 def CreateElementElectronContinuityEquation(device, region, current_model):
-    '''
-      Uses element current model for equation
-    '''
-    equation(device=device, region=region, name="ElectronContinuityEquation", variable_name="Electrons",
-             time_node_model="NCharge", node_model="ElectronGeneration",
-             element_model=current_model, variable_update="positive")
+    """
+    Uses element current model for equation
+    """
+    equation(
+        device=device,
+        region=region,
+        name="ElectronContinuityEquation",
+        variable_name="Electrons",
+        time_node_model="NCharge",
+        node_model="ElectronGeneration",
+        element_model=current_model,
+        variable_update="positive",
+    )
 
-#TODO: expand for circuit
+
+# TODO: expand for circuit
 def CreateElementContactElectronContinuityEquation(device, contact, current_model):
-    '''
-      Uses element current model for equation
-    '''
+    """
+    Uses element current model for equation
+    """
     contact_electrons_name = "{0}nodeelectrons".format(contact)
-    contact_equation(device=device, contact=contact, name="ElectronContinuityEquation",
-                     node_model=contact_electrons_name,
-                     element_current_model=current_model)
+    contact_equation(
+        device=device,
+        contact=contact,
+        name="ElectronContinuityEquation",
+        node_model=contact_electrons_name,
+        element_current_model=current_model,
+    )
+
 
 #### this version is from the direction of current flow
 #### TODO: version from interface normal distance
@@ -30,79 +47,124 @@ def CreateNormalElectricFieldFromInterfaceNormal(device, region, interface):
     ### assume the interface normal already exists
     #### Get the electric field on the element
     element_from_edge_model(edge_model="ElectricField", device=device, region=region)
-    element_from_edge_model(edge_model="ElectricField", device=device, region=region, derivative="Potential")
+    element_from_edge_model(
+        edge_model="ElectricField", device=device, region=region, derivative="Potential"
+    )
 
     #### Get the normal e field to current flow /// need to figure out sign importance for electron/hole
-    Enormal="{0}_normal_x * ElectricField_x + {0}_normal_y * ElectricField_y".format(interface)
-    CreateElementModel2d          (device, region, "Enormal", Enormal)
+    Enormal = "{0}_normal_x * ElectricField_x + {0}_normal_y * ElectricField_y".format(
+        interface
+    )
+    CreateElementModel2d(device, region, "Enormal", Enormal)
     CreateElementModelDerivative2d(device, region, "Enormal", Enormal, "Potential")
 
 
 ###### make this on a per carrier basis function
 ###### assume that low field model already exists, but not projected
 def CreateNormalElectricFieldFromCurrentFlow(device, region, low_curr):
-    dimension=get_dimension(device=device)
+    dimension = get_dimension(device=device)
     if dimension != 2:
         raise ValueError("Supported in 2d only")
 
     element_from_edge_model(edge_model=low_curr, device=device, region=region)
-    element_from_edge_model(edge_model=low_curr, device=device, region=region, derivative="Potential")
-    element_from_edge_model(edge_model=low_curr, device=device, region=region, derivative="Electrons")
-    element_from_edge_model(edge_model=low_curr, device=device, region=region, derivative="Holes")
+    element_from_edge_model(
+        edge_model=low_curr, device=device, region=region, derivative="Potential"
+    )
+    element_from_edge_model(
+        edge_model=low_curr, device=device, region=region, derivative="Electrons"
+    )
+    element_from_edge_model(
+        edge_model=low_curr, device=device, region=region, derivative="Holes"
+    )
 
     #### Get the current magnitude on the element
     #### do we need the derivative, since this is only scaling the direction?
-    #### Worry about small denominator 1e-300 is about the limit 
-    J_lf_mag="pow({0}_x^2 + {0}_y^2 + 1e-300, 0.5)".format(low_curr)
-    CreateElementModel2d(device, region, "{0}_mag".format(low_curr), "{0}".format(J_lf_mag))
+    #### Worry about small denominator 1e-300 is about the limit
+    J_lf_mag = "pow({0}_x^2 + {0}_y^2 + 1e-300, 0.5)".format(low_curr)
+    CreateElementModel2d(
+        device, region, "{0}_mag".format(low_curr), "{0}".format(J_lf_mag)
+    )
     for j in ("Electrons", "Holes", "Potential"):
         for i in ("@en0", "@en1", "@en2"):
-            ex="({0}_x * {0}_x:{1}{2} + {0}_y * {0}_y:{1}{2})/{0}_mag".format(low_curr, j, i)
-            CreateElementModel2d(device, region, "{0}_mag:{1}{2}".format(low_curr, j, i), ex)
+            ex = "({0}_x * {0}_x:{1}{2} + {0}_y * {0}_y:{1}{2})/{0}_mag".format(
+                low_curr, j, i
+            )
+            CreateElementModel2d(
+                device, region, "{0}_mag:{1}{2}".format(low_curr, j, i), ex
+            )
 
     ### This calculates the normalized current in each direction
-    for i in  ("x", "y"):
-        J_norm="{0}_{1} / {0}_mag".format(low_curr, i)
+    for i in ("x", "y"):
+        J_norm = "{0}_{1} / {0}_mag".format(low_curr, i)
         CreateElementModel2d(device, region, "{0}_norm_{1}".format(low_curr, i), J_norm)
-        CreateElementModelDerivative2d(device, region, "{0}_norm_{1}".format(low_curr, i), J_norm, "Electrons", "Holes", "Potential")
+        CreateElementModelDerivative2d(
+            device,
+            region,
+            "{0}_norm_{1}".format(low_curr, i),
+            J_norm,
+            "Electrons",
+            "Holes",
+            "Potential",
+        )
 
     #### Get the electric field on the element
     element_from_edge_model(edge_model="ElectricField", device=device, region=region)
-    element_from_edge_model(edge_model="ElectricField", device=device, region=region, derivative="Potential")
+    element_from_edge_model(
+        edge_model="ElectricField", device=device, region=region, derivative="Potential"
+    )
 
     #### Get the parallel e field to current flow
-    Eparallel_J="{0}_norm_x * ElectricField_x + {0}_norm_y * ElectricField_y".format(low_curr)
-    CreateElementModel2d          (device, region, "Eparallel_{0}".format(low_curr), Eparallel_J)
-    CreateElementModelDerivative2d(device, region, "Eparallel_{0}".format(low_curr), Eparallel_J, "Potential")
+    Eparallel_J = "{0}_norm_x * ElectricField_x + {0}_norm_y * ElectricField_y".format(
+        low_curr
+    )
+    CreateElementModel2d(device, region, "Eparallel_{0}".format(low_curr), Eparallel_J)
+    CreateElementModelDerivative2d(
+        device, region, "Eparallel_{0}".format(low_curr), Eparallel_J, "Potential"
+    )
 
     # magnitude e field
-    ElectricField_mag="pow(ElectricField_x^2 + ElectricField_y^2 + 1e-300, 0.5)"
+    ElectricField_mag = "pow(ElectricField_x^2 + ElectricField_y^2 + 1e-300, 0.5)"
     CreateElementModel2d(device, region, "ElectricField_mag", ElectricField_mag)
-    #the , turns this into an actual tuple
+    # the , turns this into an actual tuple
     for j in ("Potential",):
-        for i in ("@en0","@en1", "@en2"):
-            ex="(ElectricField_x * ElectricField_x:{0}{1} + ElectricField_y * ElectricField_y:{0}{1})/ElectricField_mag".format(j, i)
-            CreateElementModel2d(device, region, "ElectricField_mag:{0}{1}".format(j, i), ex)
+        for i in ("@en0", "@en1", "@en2"):
+            ex = "(ElectricField_x * ElectricField_x:{0}{1} + ElectricField_y * ElectricField_y:{0}{1})/ElectricField_mag".format(
+                j, i
+            )
+            CreateElementModel2d(
+                device, region, "ElectricField_mag:{0}{1}".format(j, i), ex
+            )
 
     #### Get the normal e field to current flow
-    Enormal_J="pow(max(ElectricField_mag^2 - Eparallel_{0}^2,1e-300), 0.5)".format(low_curr)
+    Enormal_J = "pow(max(ElectricField_mag^2 - Eparallel_{0}^2,1e-300), 0.5)".format(
+        low_curr
+    )
     CreateElementModel2d(device, region, "Enormal_{0}".format(low_curr), Enormal_J)
 
-    #CreateElementModelDerivative2d $device $region Enormal_{low_curr} {Enormal_J} Electrons Holes Potential
+    # CreateElementModelDerivative2d $device $region Enormal_{low_curr} {Enormal_J} Electrons Holes Potential
     for j in ("Electrons", "Holes", "Potential"):
         for i in ("@en0", "@en1", "@en2"):
-            ex="(ElectricField_mag * ElectricField_mag:{0}{1} - Eparallel_{2} * Eparallel_{2}:{0}{1})/Enormal_{2}".format(j, i, low_curr)
-            CreateElementModel2d(device, region, "Enormal_{0}:{1}{2}".format(low_curr, j, i), ex)
+            ex = "(ElectricField_mag * ElectricField_mag:{0}{1} - Eparallel_{2} * Eparallel_{2}:{0}{1})/Enormal_{2}".format(
+                j, i, low_curr
+            )
+            CreateElementModel2d(
+                device, region, "Enormal_{0}:{1}{2}".format(low_curr, j, i), ex
+            )
+
 
 def CreateElementElectronCurrent2d(device, region, name, mobility_model):
-    Jn = "ElectronCharge*{0}*EdgeInverseLength*V_t*kahan3(Electrons@en1*Bern01,  Electrons@en1*vdiff,  -Electrons@en0*Bern01)".format(mobility_model)
+    Jn = "ElectronCharge*{0}*EdgeInverseLength*V_t*kahan3(Electrons@en1*Bern01,  Electrons@en1*vdiff,  -Electrons@en0*Bern01)".format(
+        mobility_model
+    )
     CreateElementModel2d(device, region, name, Jn)
     for i in ("Electrons", "Holes", "Potential"):
         CreateElementModelDerivative2d(device, region, name, Jn, i)
 
+
 def CreateElementHoleCurrent2d(device, region, name, mobility_model):
-    Jp ="-ElectronCharge*{0}*EdgeInverseLength*V_t*kahan3(Holes@en1*Bern01, -Holes@en0*Bern01, -Holes@en0*vdiff)".format(mobility_model)
+    Jp = "-ElectronCharge*{0}*EdgeInverseLength*V_t*kahan3(Holes@en1*Bern01, -Holes@en0*Bern01, -Holes@en0*vdiff)".format(
+        mobility_model
+    )
     CreateElementModel2d(device, region, name, Jp)
     for i in ("Electrons", "Holes", "Potential"):
         CreateElementModelDerivative2d(device, region, name, Jp, i)
-

--- a/python_packages/pythonmesh.py
+++ b/python_packages/pythonmesh.py
@@ -1,132 +1,131 @@
-
-
 def parse_gmsh_file(file):
-    sections=set(['$MeshFormat', '$PhysicalNames', '$Nodes', '$Elements'])
+    sections = set(["$MeshFormat", "$PhysicalNames", "$Nodes", "$Elements"])
     lineno = 0
     section_count = 0
     section_expected = 0
     dimension = 0
-    with open(file, 'r') as ih:
-        state = 'begin' 
+    with open(file, "r") as ih:
+        state = "begin"
         for line in ih:
             line = line.rstrip()
             lineno += 1
-            if state == 'begin':
+            if state == "begin":
                 if line in sections:
                     state = line
                 else:
                     raise RuntimeError("Error Line %d" % lineno)
-            elif line.find('$End') == 0:
-                state = 'begin'
+            elif line.find("$End") == 0:
+                state = "begin"
                 section_count = 0
                 section_expected = None
-            elif state == '$MeshFormat':
+            elif state == "$MeshFormat":
                 continue
-            elif state == '$PhysicalNames':
+            elif state == "$PhysicalNames":
                 if not section_expected:
-                    section_expected=int(line)
+                    section_expected = int(line)
                     physical_names = []
                 else:
                     line = line.split()
                     name = line[2][1:-1]
                     physical_names.append((name, int(line[0]), int(line[1])))
                     section_count += 1
-            elif state == '$Nodes':
+            elif state == "$Nodes":
                 if not section_expected:
-                    section_expected=int(line)
+                    section_expected = int(line)
                     nodes = []
                 else:
                     line = line.split()
-                    nodes.append([int(line[0]), float(line[1]), float(line[2]), float(line[3])])
+                    nodes.append(
+                        [int(line[0]), float(line[1]), float(line[2]), float(line[3])]
+                    )
                     section_count += 1
-            elif state == '$Elements':
+            elif state == "$Elements":
                 if not section_expected:
-                    section_expected=int(line)
-                    elements = [None]*section_expected
+                    section_expected = int(line)
+                    elements = [None] * section_expected
                 else:
                     elements[section_count] = [int(x) for x in line.split()]
-                    section_count += 1 
+                    section_count += 1
             else:
                 raise RuntimeError("Unknown %s" % line)
     dimension = max([x[1] for x in physical_names])
     return {
-        'dimension'   : dimension,
-      'physical_names'       : physical_names,
-      'coordinates' : nodes,
-      'elements'    : elements
-    }           
+        "dimension": dimension,
+        "physical_names": physical_names,
+        "coordinates": nodes,
+        "elements": elements,
+    }
+
 
 def read_gmsh_file(filename):
-    '''reads gmsh file and converts to python representation'''
+    """reads gmsh file and converts to python representation"""
     data = parse_gmsh_file(filename)
-    #namemap = {}
-    print('%d dimension' % data['dimension'])
-    print('%d coordinates' % len(data['coordinates']))
-    #for i in sorted(data['physical_names'].keys()):
+    # namemap = {}
+    print("%d dimension" % data["dimension"])
+    print("%d coordinates" % len(data["coordinates"]))
+    # for i in sorted(data['physical_names'].keys()):
     #  print "%s %s %d" % (i, data['physical_names'][i], len(data['elements'][i]))
     #  namemap[data['physical_names'][i]] = i
 
-    coordinate_indexes = [x[0] for x in data['coordinates']]
+    coordinate_indexes = [x[0] for x in data["coordinates"]]
     max_coordinate_index = max(coordinate_indexes)
-    coordinate_to_index = [-1] * (max_coordinate_index+1)
-    for i,j in enumerate(coordinate_indexes):
-        coordinate_to_index[j] = i 
+    coordinate_to_index = [-1] * (max_coordinate_index + 1)
+    for i, j in enumerate(coordinate_indexes):
+        coordinate_to_index[j] = i
 
-    coordinates=[]
-    for i in data['coordinates']:
+    coordinates = []
+    for i in data["coordinates"]:
         coordinates.extend(i[1:])
 
-    all_physical_numbers = sorted(set([x[3] for x in data['elements']]))
-    sorted_physical_names = sorted(data['physical_names'],key = lambda x : x[0])
+    _all_physical_numbers = sorted(set([x[3] for x in data["elements"]]))
+    sorted_physical_names = sorted(data["physical_names"], key=lambda x: x[0])
     physical_number_map = {
-        1 : {},
-        2 : {},
-        3 : {},
+        1: {},
+        2: {},
+        3: {},
     }
     for i, j in enumerate(sorted_physical_names):
         # mapped dimension, physical number, new index
         physical_number_map[j[1]][j[2]] = i
     physical_names = [x[0] for x in sorted_physical_names]
 
-
-    #gmsh format
-    #elm-number elm-type number-of-tags < tag > ... node-number-list
-    #our format
+    # gmsh format
+    # elm-number elm-type number-of-tags < tag > ... node-number-list
+    # our format
     elements = []
-    for i in data['elements']:
+    for i in data["elements"]:
         t = i[1]
-        if (t == 4):
-            #tetrahedron
+        if t == 4:
+            # tetrahedron
             etype = 3
             dimension = 3
-        elif (t == 2):
-            #triangle
+        elif t == 2:
+            # triangle
             etype = 2
             dimension = 2
-        elif (t == 1):
-            #edge
+        elif t == 1:
+            # edge
             etype = 1
             dimension = 1
-        elif (t == 15):
-            #point
+        elif t == 15:
+            # point
             etype = 0
         else:
             raise RuntimeError("Cannot handle element type " % i)
 
-        #physical number
+        # physical number
         # will be remapped later
         pnum = physical_number_map[dimension][i[3]]
 
-        #nodes
+        # nodes
         # position 2 + number of tags
-        nodes = i[i[2]+3:]
+        nodes = i[i[2] + 3 :]
         nodes = [coordinate_to_index[x] for x in nodes]
         elements.extend([etype, pnum])
         elements.extend(nodes)
 
     return {
-        'physical_names' : physical_names,
-      'coordinates'    : coordinates,
-      'elements'       : elements,
+        "physical_names": physical_names,
+        "coordinates": coordinates,
+        "elements": elements,
     }
-

--- a/python_packages/ramp.py
+++ b/python_packages/ramp.py
@@ -5,50 +5,70 @@
 import devsim as ds
 from devsim.python_packages.simple_physics import GetContactBiasName, PrintCurrents
 
-def rampbias(device, contact, end_bias, step_size, min_step, max_iter, rel_error, abs_error, callback):
-    '''
-      Ramps bias with assignable callback function
-    '''
-    start_bias = ds.get_parameter(device=device, name=GetContactBiasName(contact))
-    if (start_bias < end_bias):
-        step_sign=1
-    else:
-        step_sign=-1
-    step_size=abs(step_size)
 
-    last_bias=start_bias
-    while(abs(last_bias - end_bias) > min_step):
+def rampbias(
+    device,
+    contact,
+    end_bias,
+    step_size,
+    min_step,
+    max_iter,
+    rel_error,
+    abs_error,
+    callback,
+):
+    """
+    Ramps bias with assignable callback function
+    """
+    start_bias = ds.get_parameter(device=device, name=GetContactBiasName(contact))
+    if start_bias < end_bias:
+        step_sign = 1
+    else:
+        step_sign = -1
+    step_size = abs(step_size)
+
+    last_bias = start_bias
+    while abs(last_bias - end_bias) > min_step:
         print(("%s last end %e %e") % (contact, last_bias, end_bias))
-        next_bias=last_bias + step_sign * step_size
+        next_bias = last_bias + step_sign * step_size
         if next_bias < end_bias:
-            next_step_sign=1
+            next_step_sign = 1
         else:
-            next_step_sign=-1
+            next_step_sign = -1
 
         if next_step_sign != step_sign:
-            next_bias=end_bias
+            next_bias = end_bias
             print("setting to last bias %e" % (end_bias))
             print("setting next bias %e" % (next_bias))
-        ds.set_parameter(device=device, name=GetContactBiasName(contact), value=next_bias)
+        ds.set_parameter(
+            device=device, name=GetContactBiasName(contact), value=next_bias
+        )
         try:
-            ds.solve(type="dc", absolute_error=abs_error, relative_error=rel_error, maximum_iterations=max_iter)
+            ds.solve(
+                type="dc",
+                absolute_error=abs_error,
+                relative_error=rel_error,
+                maximum_iterations=max_iter,
+            )
         except ds.error as msg:
             if str(msg).find("Convergence failure") != 0:
                 raise
-            ds.set_parameter(device=device, name=GetContactBiasName(contact), value=last_bias)
+            ds.set_parameter(
+                device=device, name=GetContactBiasName(contact), value=last_bias
+            )
             step_size *= 0.5
             print("setting new step size %e" % (step_size))
             if step_size < min_step:
                 raise RuntimeError("Minimum step size too small")
             continue
         print("Succeeded")
-        last_bias=next_bias
+        last_bias = next_bias
         callback(device)
 
+
 def printAllCurrents(device):
-    '''
-      Prints all contact currents on device
-    '''
+    """
+    Prints all contact currents on device
+    """
     for c in ds.get_contact_list(device=device):
         PrintCurrents(device, c)
-

--- a/python_packages/simple_dd.py
+++ b/python_packages/simple_dd.py
@@ -2,30 +2,41 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from devsim.python_packages.model_create import CreateEdgeModel, CreateEdgeModelDerivatives, InEdgeModelList, EnsureEdgeFromNodeModelExists
+from devsim.python_packages.model_create import (
+    CreateEdgeModel,
+    CreateEdgeModelDerivatives,
+    InEdgeModelList,
+    EnsureEdgeFromNodeModelExists,
+)
 
-def CreateBernoulli (device, region):
-    '''
+
+def CreateBernoulli(device, region):
+    """
     Creates the Bernoulli function for Scharfetter Gummel
-    '''
+    """
     #### test for requisite models here
     EnsureEdgeFromNodeModelExists(device, region, "Potential")
-    vdiffstr="(Potential@n0 - Potential@n1)/V_t"
+    vdiffstr = "(Potential@n0 - Potential@n1)/V_t"
     CreateEdgeModel(device, region, "vdiff", vdiffstr)
-    CreateEdgeModel(device, region, "vdiff:Potential@n0",  "V_t^(-1)")
-    CreateEdgeModel(device, region, "vdiff:Potential@n1",  "-vdiff:Potential@n0")
-    CreateEdgeModel(device, region, "Bern01",              "B(vdiff)")
-    CreateEdgeModel(device, region, "Bern01:Potential@n0", "dBdx(vdiff) * vdiff:Potential@n0")
+    CreateEdgeModel(device, region, "vdiff:Potential@n0", "V_t^(-1)")
+    CreateEdgeModel(device, region, "vdiff:Potential@n1", "-vdiff:Potential@n0")
+    CreateEdgeModel(device, region, "Bern01", "B(vdiff)")
+    CreateEdgeModel(
+        device, region, "Bern01:Potential@n0", "dBdx(vdiff) * vdiff:Potential@n0"
+    )
     CreateEdgeModel(device, region, "Bern01:Potential@n1", "-Bern01:Potential@n0")
-    #identity of Bernoulli functions
+    # identity of Bernoulli functions
+
+
 #  CreateEdgeModel(device, region, "Bern10",              "Bern01 + vdiff")
 #  CreateEdgeModel(device, region, "Bern10:Potential@n0", "Bern01:Potential@n0 + vdiff:Potential@n0")
 #  CreateEdgeModel(device, region, "Bern10:Potential@n1", "Bern01:Potential@n1 + vdiff:Potential@n1")
 
+
 def CreateElectronCurrent(device, region, mu_n):
-    '''
+    """
     Electron current
-    '''
+    """
     EnsureEdgeFromNodeModelExists(device, region, "Potential")
     EnsureEdgeFromNodeModelExists(device, region, "Electrons")
     EnsureEdgeFromNodeModelExists(device, region, "Holes")
@@ -33,28 +44,32 @@ def CreateElectronCurrent(device, region, mu_n):
     if not InEdgeModelList(device, region, "Bern01"):
         CreateBernoulli(device, region)
     #### test for requisite models here
-#  Jn = "ElectronCharge*{0}*EdgeInverseLength*V_t*(Electrons@n1*Bern10 - Electrons@n0*Bern01)".format(mu_n)
-    Jn = "ElectronCharge*{0}*EdgeInverseLength*V_t*kahan3(Electrons@n1*Bern01,  Electrons@n1*vdiff,  -Electrons@n0*Bern01)".format(mu_n)
-#  Jn = "ElectronCharge*{0}*EdgeInverseLength*V_t*((Electrons@n1-Electrons@n0)*Bern01 +  Electrons@n1*vdiff)".format(mu_n)
+    #  Jn = "ElectronCharge*{0}*EdgeInverseLength*V_t*(Electrons@n1*Bern10 - Electrons@n0*Bern01)".format(mu_n)
+    Jn = "ElectronCharge*{0}*EdgeInverseLength*V_t*kahan3(Electrons@n1*Bern01,  Electrons@n1*vdiff,  -Electrons@n0*Bern01)".format(
+        mu_n
+    )
+    #  Jn = "ElectronCharge*{0}*EdgeInverseLength*V_t*((Electrons@n1-Electrons@n0)*Bern01 +  Electrons@n1*vdiff)".format(mu_n)
 
     CreateEdgeModel(device, region, "ElectronCurrent", Jn)
     for i in ("Electrons", "Potential", "Holes"):
         CreateEdgeModelDerivatives(device, region, "ElectronCurrent", Jn, i)
 
+
 def CreateHoleCurrent(device, region, mu_p):
-    '''
+    """
     Hole current
-    '''
+    """
     EnsureEdgeFromNodeModelExists(device, region, "Potential")
     EnsureEdgeFromNodeModelExists(device, region, "Holes")
     # Make sure the bernoulli functions exist
     if not InEdgeModelList(device, region, "Bern01"):
         CreateBernoulli(device, region)
     ##### test for requisite models here
-#  Jp ="-ElectronCharge*{0}*EdgeInverseLength*V_t*(Holes@n1*Bern01 - Holes@n0*Bern10)".format(mu_p)
-    Jp ="-ElectronCharge*{0}*EdgeInverseLength*V_t*kahan3(Holes@n1*Bern01, -Holes@n0*Bern01, -Holes@n0*vdiff)".format(mu_p)
-#  Jp ="-ElectronCharge*{0}*EdgeInverseLength*V_t*((Holes@n1 - Holes@n0)*Bern01 - Holes@n0*vdiff)".format(mu_p)
+    #  Jp ="-ElectronCharge*{0}*EdgeInverseLength*V_t*(Holes@n1*Bern01 - Holes@n0*Bern10)".format(mu_p)
+    Jp = "-ElectronCharge*{0}*EdgeInverseLength*V_t*kahan3(Holes@n1*Bern01, -Holes@n0*Bern01, -Holes@n0*vdiff)".format(
+        mu_p
+    )
+    #  Jp ="-ElectronCharge*{0}*EdgeInverseLength*V_t*((Holes@n1 - Holes@n0)*Bern01 - Holes@n0*vdiff)".format(mu_p)
     CreateEdgeModel(device, region, "HoleCurrent", Jp)
     for i in ("Holes", "Potential", "Electrons"):
         CreateEdgeModelDerivatives(device, region, "HoleCurrent", Jp, i)
-

--- a/python_packages/simple_physics.py
+++ b/python_packages/simple_physics.py
@@ -3,99 +3,148 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from .simple_dd import CreateBernoulli, CreateElectronCurrent, CreateHoleCurrent
+from .model_create import (
+    CreateSolution,
+    CreateNodeModel,
+    CreateNodeModelDerivative,
+    CreateContactNodeModel,
+    CreateContactNodeModelDerivative,
+    CreateEdgeModel,
+    CreateEdgeModelDerivatives,
+    CreateContinuousInterfaceModel,
+    InEdgeModelList,
+    InNodeModelList,
+)
 
-from devsim import contact_equation, equation, get_contact_current, get_parameter, interface_equation, set_parameter
+from devsim import (
+    contact_equation,
+    equation,
+    get_contact_current,
+    get_parameter,
+    interface_equation,
+    set_parameter,
+)
 
-contactcharge_edge="contactcharge_edge"
-ece_name="ElectronContinuityEquation"
-hce_name="HoleContinuityEquation"
+contactcharge_edge = "contactcharge_edge"
+ece_name = "ElectronContinuityEquation"
+hce_name = "HoleContinuityEquation"
 celec_model = "(1e-10 + 0.5*abs(NetDoping+(NetDoping^2 + 4 * n_i^2)^(0.5)))"
 chole_model = "(1e-10 + 0.5*abs(-NetDoping+(NetDoping^2 + 4 * n_i^2)^(0.5)))"
 
-q      = 1.6e-19 # coul
-k      = 1.3806503e-23 # J/K
-eps_0  = 8.85e-14 # F/cm^2
-#T      = 300 # K
+q = 1.6e-19  # coul
+k = 1.3806503e-23  # J/K
+eps_0 = 8.85e-14  # F/cm^2
+# T      = 300 # K
 eps_si = 11.1
 eps_ox = 3.9
 # TODO: make this temperature dependent
-n_i    = 1.0e10 # #/cm^3
+n_i = 1.0e10  # #/cm^3
 # constant in our approximation
-mu_n   = 400
-mu_p   = 200
+mu_n = 400
+mu_p = 200
 
 
 def GetContactBiasName(contact):
     return "{0}_bias".format(contact)
 
+
 def GetContactNodeModelName(contact):
     return "{0}nodemodel".format(contact)
 
-def PrintCurrents(device, contact):
-    '''
-       print out contact currents
-    '''
-    # TODO add charge
-    contact_bias_name = GetContactBiasName(contact)
-    electron_current= get_contact_current(device=device, contact=contact, equation=ece_name)
-    hole_current    = get_contact_current(device=device, contact=contact, equation=hce_name)
-    total_current   = electron_current + hole_current                                        
-    voltage         = get_parameter(device=device, name=GetContactBiasName(contact))
-    print("{0}\t{1}\t{2}\t{3}\t{4}".format(contact, voltage, electron_current, hole_current, total_current))
 
-#in the future, worry about workfunction
+def PrintCurrents(device, contact):
+    """
+    print out contact currents
+    """
+    # TODO add charge
+    _contact_bias_name = GetContactBiasName(contact)
+    electron_current = get_contact_current(
+        device=device, contact=contact, equation=ece_name
+    )
+    hole_current = get_contact_current(
+        device=device, contact=contact, equation=hce_name
+    )
+    total_current = electron_current + hole_current
+    voltage = get_parameter(device=device, name=GetContactBiasName(contact))
+    print(
+        "{0}\t{1}\t{2}\t{3}\t{4}".format(
+            contact, voltage, electron_current, hole_current, total_current
+        )
+    )
+
+
+# in the future, worry about workfunction
 def CreateOxideContact(device, region, contact):
-    conteq="Permittivity*ElectricField"
-    contact_bias_name  = GetContactBiasName(contact)
+    _conteq = "Permittivity*ElectricField"
+    contact_bias_name = GetContactBiasName(contact)
     contact_model_name = GetContactNodeModelName(contact)
     eq = "Potential - {0}".format(contact_bias_name)
     CreateContactNodeModel(device, contact, contact_model_name, eq)
-    CreateContactNodeModelDerivative(device, contact, contact_model_name, eq, "Potential")
+    CreateContactNodeModelDerivative(
+        device, contact, contact_model_name, eq, "Potential"
+    )
 
-    #TODO: make everyone use dfield
+    # TODO: make everyone use dfield
     if not InEdgeModelList(device, region, contactcharge_edge):
-        CreateEdgeModel(device, region, contactcharge_edge, "Permittivity*ElectricField")
-        CreateEdgeModelDerivatives(device, region, contactcharge_edge, "Permittivity*ElectricField", "Potential")
+        CreateEdgeModel(
+            device, region, contactcharge_edge, "Permittivity*ElectricField"
+        )
+        CreateEdgeModelDerivatives(
+            device,
+            region,
+            contactcharge_edge,
+            "Permittivity*ElectricField",
+            "Potential",
+        )
 
-    contact_equation(device=device, contact=contact, name="PotentialEquation",
-                     node_model=contact_model_name, edge_charge_model= contactcharge_edge)
-
-
+    contact_equation(
+        device=device,
+        contact=contact,
+        name="PotentialEquation",
+        node_model=contact_model_name,
+        edge_charge_model=contactcharge_edge,
+    )
 
 
 #####
 ##### Constants
 #####
 def SetOxideParameters(device, region, T):
-    '''
-      Sets physical parameters
-    '''
-    set_parameter(device=device, region=region, name="Permittivity",   value=eps_ox * eps_0)
+    """
+    Sets physical parameters
+    """
+    set_parameter(
+        device=device, region=region, name="Permittivity", value=eps_ox * eps_0
+    )
     set_parameter(device=device, region=region, name="ElectronCharge", value=q)
 
+
 def SetSiliconParameters(device, region, T):
-    '''
-      Sets physical parameters assuming constants
-    '''
+    """
+    Sets physical parameters assuming constants
+    """
     #### TODO: make T a free parameter and T dependent parameters as models
-    set_parameter(device=device, region=region, name="Permittivity",   value=eps_si * eps_0)
+    set_parameter(
+        device=device, region=region, name="Permittivity", value=eps_si * eps_0
+    )
     set_parameter(device=device, region=region, name="ElectronCharge", value=q)
-    set_parameter(device=device, region=region, name="n_i",            value=n_i)
-    set_parameter(device=device, region=region, name="T",              value=T)
-    set_parameter(device=device, region=region, name="kT",             value=k * T)
-    set_parameter(device=device, region=region, name="V_t",            value=k*T/q)
-    set_parameter(device=device, region=region, name="mu_n",           value=mu_n)
-    set_parameter(device=device, region=region, name="mu_p",           value=mu_p)
-    #default SRH parameters
+    set_parameter(device=device, region=region, name="n_i", value=n_i)
+    set_parameter(device=device, region=region, name="T", value=T)
+    set_parameter(device=device, region=region, name="kT", value=k * T)
+    set_parameter(device=device, region=region, name="V_t", value=k * T / q)
+    set_parameter(device=device, region=region, name="mu_n", value=mu_n)
+    set_parameter(device=device, region=region, name="mu_p", value=mu_p)
+    # default SRH parameters
     set_parameter(device=device, region=region, name="n1", value=n_i)
     set_parameter(device=device, region=region, name="p1", value=n_i)
     set_parameter(device=device, region=region, name="taun", value=1e-5)
     set_parameter(device=device, region=region, name="taup", value=1e-5)
 
+
 def CreateSiliconPotentialOnly(device, region):
-    '''
-      Creates the physical models for a Silicon region
-    '''
+    """
+    Creates the physical models for a Silicon region
+    """
     if not InNodeModelList(device, region, "Potential"):
         print("Creating Node Solution Potential")
         CreateSolution(device, region, "Potential")
@@ -107,9 +156,9 @@ def CreateSiliconPotentialOnly(device, region):
     # require NetDoping
     for i in (
         ("IntrinsicElectrons", elec_i),
-         ("IntrinsicHoles", hole_i),
-         ("IntrinsicCharge", charge_i),
-         ("PotentialIntrinsicCharge", pcharge_i)
+        ("IntrinsicHoles", hole_i),
+        ("IntrinsicCharge", charge_i),
+        ("PotentialIntrinsicCharge", pcharge_i),
     ):
         n = i[0]
         e = i[1]
@@ -118,30 +167,46 @@ def CreateSiliconPotentialOnly(device, region):
 
     ### TODO: Edge Average Model
     for i in (
-        ("ElectricField",     "(Potential@n0-Potential@n1)*EdgeInverseLength"),
-      ("PotentialEdgeFlux", "Permittivity * ElectricField")
+        ("ElectricField", "(Potential@n0-Potential@n1)*EdgeInverseLength"),
+        ("PotentialEdgeFlux", "Permittivity * ElectricField"),
     ):
         n = i[0]
         e = i[1]
         CreateEdgeModel(device, region, n, e)
         CreateEdgeModelDerivatives(device, region, n, e, "Potential")
 
-    equation(device=device, region=region, name="PotentialEquation", variable_name="Potential",
-             node_model="PotentialIntrinsicCharge", edge_model="PotentialEdgeFlux", variable_update="log_damp")
+    equation(
+        device=device,
+        region=region,
+        name="PotentialEquation",
+        variable_name="Potential",
+        node_model="PotentialIntrinsicCharge",
+        edge_model="PotentialEdgeFlux",
+        variable_update="log_damp",
+    )
+
 
 def CreateSiliconPotentialOnlyContact(device, region, contact, is_circuit=False):
-    '''
-      Creates the potential equation at the contact
-      if is_circuit is true, than use node given by GetContactBiasName
-    '''
+    """
+    Creates the potential equation at the contact
+    if is_circuit is true, than use node given by GetContactBiasName
+    """
     # Means of determining contact charge
     # Same for all contacts
     #### TODO: This is the same as D-Field
     if not InEdgeModelList(device, region, "contactcharge_edge"):
-        CreateEdgeModel(device, region, "contactcharge_edge", "Permittivity*ElectricField")
-        CreateEdgeModelDerivatives(device, region, "contactcharge_edge", "Permittivity*ElectricField", "Potential")
+        CreateEdgeModel(
+            device, region, "contactcharge_edge", "Permittivity*ElectricField"
+        )
+        CreateEdgeModelDerivatives(
+            device,
+            region,
+            "contactcharge_edge",
+            "Permittivity*ElectricField",
+            "Potential",
+        )
 
-#  set_parameter(device=device, region=region, name=GetContactBiasName(contact), value=0.0)
+    #  set_parameter(device=device, region=region, name=GetContactBiasName(contact), value=0.0)
 
     contact_model = "Potential -{0} + ifelse(NetDoping > 0, \
     -V_t*log({1}/n_i), \
@@ -150,23 +215,46 @@ def CreateSiliconPotentialOnlyContact(device, region, contact, is_circuit=False)
     contact_model_name = GetContactNodeModelName(contact)
     CreateContactNodeModel(device, contact, contact_model_name, contact_model)
     # Simplify it too complicated
-    CreateContactNodeModel(device, contact, "{0}:{1}".format(contact_model_name,"Potential"), "1")
+    CreateContactNodeModel(
+        device, contact, "{0}:{1}".format(contact_model_name, "Potential"), "1"
+    )
     if is_circuit:
-        CreateContactNodeModel(device, contact, "{0}:{1}".format(contact_model_name,GetContactBiasName(contact)), "-1")
+        CreateContactNodeModel(
+            device,
+            contact,
+            "{0}:{1}".format(contact_model_name, GetContactBiasName(contact)),
+            "-1",
+        )
 
     if is_circuit:
-        contact_equation(device=device, contact=contact, name="PotentialEquation",
-                         node_model=contact_model_name, edge_model="",
-                         node_charge_model="", edge_charge_model="contactcharge_edge",
-                         node_current_model="", edge_current_model="", circuit_node=GetContactBiasName(contact))
+        contact_equation(
+            device=device,
+            contact=contact,
+            name="PotentialEquation",
+            node_model=contact_model_name,
+            edge_model="",
+            node_charge_model="",
+            edge_charge_model="contactcharge_edge",
+            node_current_model="",
+            edge_current_model="",
+            circuit_node=GetContactBiasName(contact),
+        )
     else:
-        contact_equation(device=device, contact=contact, name="PotentialEquation",
-                         node_model=contact_model_name, edge_model="",
-                         node_charge_model="", edge_charge_model="contactcharge_edge",
-                         node_current_model="", edge_current_model="")
+        contact_equation(
+            device=device,
+            contact=contact,
+            name="PotentialEquation",
+            node_model=contact_model_name,
+            edge_model="",
+            node_charge_model="",
+            edge_charge_model="contactcharge_edge",
+            node_current_model="",
+            edge_current_model="",
+        )
+
 
 def CreateSRH(device, region):
-    USRH="(Electrons*Holes - n_i^2)/(taup*(Electrons + n1) + taun*(Holes + p1))"
+    USRH = "(Electrons*Holes - n_i^2)/(taup*(Electrons + n1) + taun*(Holes + p1))"
     Gn = "-ElectronCharge * USRH"
     Gp = "+ElectronCharge * USRH"
     CreateNodeModel(device, region, "USRH", USRH)
@@ -177,6 +265,7 @@ def CreateSRH(device, region):
         CreateNodeModelDerivative(device, region, "ElectronGeneration", Gn, i)
         CreateNodeModelDerivative(device, region, "HoleGeneration", Gp, i)
 
+
 def CreateECE(device, region, mu_n):
     CreateElectronCurrent(device, region, mu_n)
 
@@ -184,9 +273,17 @@ def CreateECE(device, region, mu_n):
     CreateNodeModel(device, region, "NCharge", NCharge)
     CreateNodeModelDerivative(device, region, "NCharge", NCharge, "Electrons")
 
-    equation(device=device, region=region, name="ElectronContinuityEquation", variable_name="Electrons",
-             time_node_model = "NCharge",
-             edge_model="ElectronCurrent", variable_update="positive", node_model="ElectronGeneration")
+    equation(
+        device=device,
+        region=region,
+        name="ElectronContinuityEquation",
+        variable_name="Electrons",
+        time_node_model="NCharge",
+        edge_model="ElectronCurrent",
+        variable_update="positive",
+        node_model="ElectronGeneration",
+    )
+
 
 def CreateHCE(device, region, mu_p):
     CreateHoleCurrent(device, region, mu_p)
@@ -194,9 +291,17 @@ def CreateHCE(device, region, mu_p):
     CreateNodeModel(device, region, "PCharge", PCharge)
     CreateNodeModelDerivative(device, region, "PCharge", PCharge, "Holes")
 
-    equation(device=device, region=region, name="HoleContinuityEquation", variable_name="Holes",
-             time_node_model = "PCharge",
-             edge_model="HoleCurrent", variable_update="positive", node_model="HoleGeneration")
+    equation(
+        device=device,
+        region=region,
+        name="HoleContinuityEquation",
+        variable_name="Holes",
+        time_node_model="PCharge",
+        edge_model="HoleCurrent",
+        variable_update="positive",
+        node_model="HoleGeneration",
+    )
+
 
 def CreatePE(device, region):
     pne = "-ElectronCharge*kahan3(Holes, -Electrons, NetDoping)"
@@ -204,9 +309,16 @@ def CreatePE(device, region):
     CreateNodeModelDerivative(device, region, "PotentialNodeCharge", pne, "Electrons")
     CreateNodeModelDerivative(device, region, "PotentialNodeCharge", pne, "Holes")
 
-    equation(device=device, region=region, name="PotentialEquation", variable_name="Potential",
-             node_model="PotentialNodeCharge", edge_model="PotentialEdgeFlux",
-             time_node_model="", variable_update="log_damp")
+    equation(
+        device=device,
+        region=region,
+        name="PotentialEquation",
+        variable_name="Potential",
+        node_model="PotentialNodeCharge",
+        edge_model="PotentialEdgeFlux",
+        time_node_model="",
+        variable_update="log_damp",
+    )
 
 
 def CreateSiliconDriftDiffusion(device, region, mu_n="mu_n", mu_p="mu_p"):
@@ -217,81 +329,135 @@ def CreateSiliconDriftDiffusion(device, region, mu_n="mu_n", mu_p="mu_p"):
     CreateHCE(device, region, mu_p)
 
 
-def CreateSiliconDriftDiffusionAtContact(device, region, contact, is_circuit=False): 
-    '''
-      Restrict electrons and holes to their equilibrium values
-      Integrates current into circuit
-    '''
-    contact_electrons_model = "Electrons - ifelse(NetDoping > 0, {0}, n_i^2/{1})".format(celec_model, chole_model)
-    contact_holes_model = "Holes - ifelse(NetDoping < 0, +{1}, +n_i^2/{0})".format(celec_model, chole_model)
+def CreateSiliconDriftDiffusionAtContact(device, region, contact, is_circuit=False):
+    """
+    Restrict electrons and holes to their equilibrium values
+    Integrates current into circuit
+    """
+    contact_electrons_model = (
+        "Electrons - ifelse(NetDoping > 0, {0}, n_i^2/{1})".format(
+            celec_model, chole_model
+        )
+    )
+    contact_holes_model = "Holes - ifelse(NetDoping < 0, +{1}, +n_i^2/{0})".format(
+        celec_model, chole_model
+    )
     contact_electrons_name = "{0}nodeelectrons".format(contact)
     contact_holes_name = "{0}nodeholes".format(contact)
 
-    CreateContactNodeModel(device, contact, contact_electrons_name, contact_electrons_model)
-    #TODO: The simplification of the ifelse statement is time consuming
-#  CreateContactNodeModelDerivative(device, contact, contact_electrons_name, contact_electrons_model, "Electrons")
-    CreateContactNodeModel(device, contact, "{0}:{1}".format(contact_electrons_name, "Electrons"), "1")
+    CreateContactNodeModel(
+        device, contact, contact_electrons_name, contact_electrons_model
+    )
+    # TODO: The simplification of the ifelse statement is time consuming
+    #  CreateContactNodeModelDerivative(device, contact, contact_electrons_name, contact_electrons_model, "Electrons")
+    CreateContactNodeModel(
+        device, contact, "{0}:{1}".format(contact_electrons_name, "Electrons"), "1"
+    )
 
     CreateContactNodeModel(device, contact, contact_holes_name, contact_holes_model)
-    CreateContactNodeModel(device, contact, "{0}:{1}".format(contact_holes_name, "Holes"), "1")
+    CreateContactNodeModel(
+        device, contact, "{0}:{1}".format(contact_holes_name, "Holes"), "1"
+    )
 
-    #TODO: keyword args
+    # TODO: keyword args
     if is_circuit:
-        contact_equation(device=device, contact=contact, name="ElectronContinuityEquation",
-                         node_model=contact_electrons_name,
-                         edge_current_model="ElectronCurrent", circuit_node=GetContactBiasName(contact))
+        contact_equation(
+            device=device,
+            contact=contact,
+            name="ElectronContinuityEquation",
+            node_model=contact_electrons_name,
+            edge_current_model="ElectronCurrent",
+            circuit_node=GetContactBiasName(contact),
+        )
 
-        contact_equation(device=device, contact=contact, name="HoleContinuityEquation",
-                         node_model=contact_holes_name,
-                         edge_current_model="HoleCurrent", circuit_node=GetContactBiasName(contact))
+        contact_equation(
+            device=device,
+            contact=contact,
+            name="HoleContinuityEquation",
+            node_model=contact_holes_name,
+            edge_current_model="HoleCurrent",
+            circuit_node=GetContactBiasName(contact),
+        )
 
     else:
-        contact_equation(device=device, contact=contact, name="ElectronContinuityEquation",
-                         node_model=contact_electrons_name,
-                         edge_current_model="ElectronCurrent")
+        contact_equation(
+            device=device,
+            contact=contact,
+            name="ElectronContinuityEquation",
+            node_model=contact_electrons_name,
+            edge_current_model="ElectronCurrent",
+        )
 
-        contact_equation(device=device, contact=contact, name="HoleContinuityEquation",
-                         node_model=contact_holes_name,
-                         edge_current_model="HoleCurrent")
+        contact_equation(
+            device=device,
+            contact=contact,
+            name="HoleContinuityEquation",
+            node_model=contact_holes_name,
+            edge_current_model="HoleCurrent",
+        )
 
 
 def CreateOxidePotentialOnly(device, region, update_type="default"):
-    '''
-      Create electric field model in oxide
-      Creates Potential solution variable if not available
-    '''
+    """
+    Create electric field model in oxide
+    Creates Potential solution variable if not available
+    """
     if not InNodeModelList(device, region, "Potential"):
         print("Creating Node Solution Potential")
         CreateSolution(device, region, "Potential")
 
-    efield="(Potential@n0 - Potential@n1)*EdgeInverseLength"
+    efield = "(Potential@n0 - Potential@n1)*EdgeInverseLength"
     # this needs to remove derivatives w.r.t. independents
     CreateEdgeModel(device, region, "ElectricField", efield)
     CreateEdgeModelDerivatives(device, region, "ElectricField", efield, "Potential")
-    dfield="Permittivity*ElectricField"
+    dfield = "Permittivity*ElectricField"
     CreateEdgeModel(device, region, "PotentialEdgeFlux", dfield)
     CreateEdgeModelDerivatives(device, region, "PotentialEdgeFlux", dfield, "Potential")
-    equation(device=device, region=region, name="PotentialEquation", variable_name="Potential",
-             edge_model="PotentialEdgeFlux", variable_update=update_type)
+    equation(
+        device=device,
+        region=region,
+        name="PotentialEquation",
+        variable_name="Potential",
+        edge_model="PotentialEdgeFlux",
+        variable_update=update_type,
+    )
 
 
 def CreateSiliconOxideInterface(device, interface):
-    '''
-      continuous potential at interface
-    '''
+    """
+    continuous potential at interface
+    """
     model_name = CreateContinuousInterfaceModel(device, interface, "Potential")
-    interface_equation(device=device, interface=interface, name="PotentialEquation", interface_model=model_name, type="continuous")
+    interface_equation(
+        device=device,
+        interface=interface,
+        name="PotentialEquation",
+        interface_model=model_name,
+        type="continuous",
+    )
+
 
 #
 ##TODO: similar model for silicon/silicon interface
 ## should use quasi-fermi potential
 def CreateSiliconSiliconInterface(device, interface):
-    '''
-      Enforces potential, electron, and hole continuity across the interface
-    '''
+    """
+    Enforces potential, electron, and hole continuity across the interface
+    """
     CreateSiliconOxideInterface(device, interface)
     ename = CreateContinuousInterfaceModel(device, interface, "Electrons")
-    interface_equation(device=device, interface=interface, name="ElectronContinuityEquation", interface_model=ename, type="continuous")
+    interface_equation(
+        device=device,
+        interface=interface,
+        name="ElectronContinuityEquation",
+        interface_model=ename,
+        type="continuous",
+    )
     hname = CreateContinuousInterfaceModel(device, interface, "Holes")
-    interface_equation(device=device, interface=interface, name="HoleContinuityEquation", interface_model=hname, type="continuous")
-
+    interface_equation(
+        device=device,
+        interface=interface,
+        name="HoleContinuityEquation",
+        interface_model=hname,
+        type="continuous",
+    )

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,79 @@
+# Exclude a variety of commonly ignored directories.
+exclude = [
+    ".bzr",
+    ".direnv",
+    ".eggs",
+    ".git",
+    ".git-rewrite",
+    ".hg",
+    ".ipynb_checkpoints",
+    ".mypy_cache",
+    ".nox",
+    ".pants.d",
+    ".pyenv",
+    ".pytest_cache",
+    ".pytype",
+    ".ruff_cache",
+    ".svn",
+    ".tox",
+    ".venv",
+    ".vscode",
+    "__pypackages__",
+    "_build",
+    "buck-out",
+    "build",
+    "dist",
+    "node_modules",
+    "site-packages",
+    "venv",
+    "external",
+    "umfpack"
+]
+
+# Same as Black.
+line-length = 88
+indent-width = 4
+
+# Assume Python 3.8
+target-version = "py38"
+
+[lint]
+# Enable Pyflakes (`F`) and a subset of the pycodestyle (`E`)  codes by default.
+# Unlike Flake8, Ruff doesn't enable pycodestyle warnings (`W`) or
+# McCabe complexity (`C901`) by default.
+select = ["E4", "E7", "E9", "F"]
+ignore = []
+
+# Allow fix for all enabled rules (when `--fix`) is provided.
+fixable = ["ALL"]
+unfixable = []
+
+# Allow unused variables when underscore-prefixed.
+dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
+
+[format]
+# Like Black, use double quotes for strings.
+quote-style = "double"
+
+# Like Black, indent with spaces, rather than tabs.
+indent-style = "space"
+
+# Like Black, respect magic trailing commas.
+skip-magic-trailing-comma = false
+
+# Like Black, automatically detect the appropriate line ending.
+line-ending = "auto"
+
+# Enable auto-formatting of code examples in docstrings. Markdown,
+# reStructuredText code/literal blocks and doctests are all supported.
+#
+# This is currently disabled by default, but it is planned for this
+# to be opt-out in the future.
+docstring-code-format = false
+
+# Set the line length limit used when formatting code snippets in
+# docstrings.
+#
+# This only has an effect when the `docstring-code-format` setting is
+# enabled.
+docstring-code-line-length = "dynamic"

--- a/ruff.toml
+++ b/ruff.toml
@@ -34,8 +34,8 @@ exclude = [
 line-length = 88
 indent-width = 4
 
-# Assume Python 3.8
-target-version = "py38"
+# Assume Python 3.7 minimum
+target-version = "py37"
 
 [lint]
 # Enable Pyflakes (`F`) and a subset of the pycodestyle (`E`)  codes by default.

--- a/testing/Fermi1.py
+++ b/testing/Fermi1.py
@@ -2,26 +2,36 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-#Purpose: Fermi integral and inverse
+# Purpose: Fermi integral and inverse
 
 import devsim
 import test_common
 
-device="MyDevice"
-region="MyRegion"
+device = "MyDevice"
+region = "MyRegion"
 
 test_common.CreateSimpleMesh(device, region)
 
 devsim.set_parameter(name="Nc", value=1e22)
-devsim.node_model(device=device, region=region, name="Electrons", equation="2e15*(1 - x) + 1e10;")
+devsim.node_model(
+    device=device, region=region, name="Electrons", equation="2e15*(1 - x) + 1e10;"
+)
 devsim.node_model(device=device, region=region, name="r", equation="Electrons/Nc;")
 devsim.node_model(device=device, region=region, name="Eta", equation="InvFermi(r);")
 devsim.node_model(device=device, region=region, name="r2", equation="Fermi(Eta);")
 
-devsim.node_model(device=device, region=region, name="Eta:r", equation="diff(InvFermi(r),r);")
-devsim.node_model(device=device, region=region, name="r2:Eta", equation="diff(Fermi(Eta),Eta);")
-devsim.node_model(device=device, region=region, name="r3:Eta", equation="dFermidx(Eta);")
-devsim.node_model(device=device, region=region, name="r4:Eta", equation="1.0/dInvFermidx(r2);")
+devsim.node_model(
+    device=device, region=region, name="Eta:r", equation="diff(InvFermi(r),r);"
+)
+devsim.node_model(
+    device=device, region=region, name="r2:Eta", equation="diff(Fermi(Eta),Eta);"
+)
+devsim.node_model(
+    device=device, region=region, name="r3:Eta", equation="dFermidx(Eta);"
+)
+devsim.node_model(
+    device=device, region=region, name="r4:Eta", equation="1.0/dInvFermidx(r2);"
+)
 
 devsim.print_node_values(device=device, region=region, name="Electrons")
 devsim.print_node_values(device=device, region=region, name="r")
@@ -36,8 +46,14 @@ devsim.set_parameter(name="Nc", value=3.23e19)
 devsim.set_parameter(name="Nv", value=1.83e19)
 devsim.set_parameter(name="Eg", value=1.12)
 devsim.set_parameter(name="Vt", value=0.0259)
-devsim.node_model(device=device, region=region, name="ni_f", equation="(Nc*Nv)^0.5 * Fermi(-Eg/(2*Vt))")
-devsim.node_model(device=device, region=region, name="ni_b", equation="(Nc*Nv)^0.5 * exp(-Eg/(2*Vt))")
+devsim.node_model(
+    device=device,
+    region=region,
+    name="ni_f",
+    equation="(Nc*Nv)^0.5 * Fermi(-Eg/(2*Vt))",
+)
+devsim.node_model(
+    device=device, region=region, name="ni_b", equation="(Nc*Nv)^0.5 * exp(-Eg/(2*Vt))"
+)
 devsim.print_node_values(device=device, region=region, name="ni_f")
 devsim.print_node_values(device=device, region=region, name="ni_b")
-

--- a/testing/Fermi1_float128.py
+++ b/testing/Fermi1_float128.py
@@ -2,17 +2,17 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-#Purpose: Fermi integral and inverse
+# Purpose: Fermi integral and inverse
 
 import devsim
 import sys
 
-if not devsim.get_parameter(name='info')['extended_precision']:
+if not devsim.get_parameter(name="info")["extended_precision"]:
     print("Extended precision support is not available with this version")
     sys.exit(0)
 
-devsim.set_parameter(name = "extended_solver", value=True)
-devsim.set_parameter(name = "extended_model", value=True)
-devsim.set_parameter(name = "extended_equation", value=True)
+devsim.set_parameter(name="extended_solver", value=True)
+devsim.set_parameter(name="extended_model", value=True)
+devsim.set_parameter(name="extended_equation", value=True)
 
-import Fermi1
+import Fermi1  # noqa: E402, F401

--- a/testing/GaussFermi.py
+++ b/testing/GaussFermi.py
@@ -2,16 +2,15 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-#Purpose: Fermi integral and inverse
+# Purpose: Fermi integral and inverse
 
 import devsim
 import test_common
 
-device="MyDevice"
-region="MyRegion"
+device = "MyDevice"
+region = "MyRegion"
 
 test_common.CreateSimpleMesh(device, region)
-
 
 
 devsim.node_model(device=device, region=region, name="zeta1", equation="x*70 - 70;")
@@ -19,11 +18,15 @@ devsim.node_model(device=device, region=region, name="g1", equation="gfi(zeta1, 
 devsim.node_model(device=device, region=region, name="zeta2", equation="igfi(g1, s);")
 
 
-devsim.node_model(device=device, region=region, name="dgfidx1", equation="diff(gfi(zeta1, s), zeta1);")
-devsim.node_model(device=device, region=region, name="digfidx1", equation="diff(igfi(g1, s), g1);")
+devsim.node_model(
+    device=device, region=region, name="dgfidx1", equation="diff(gfi(zeta1, s), zeta1);"
+)
+devsim.node_model(
+    device=device, region=region, name="digfidx1", equation="diff(igfi(g1, s), g1);"
+)
 devsim.node_model(device=device, region=region, name="dgfidx2", equation="1/digfidx1;")
 
-for s in (2,4,6,8):
+for s in (2, 4, 6, 8):
     devsim.set_parameter(name="s", value=s)
 
     devsim.print_node_values(device=device, region=region, name="zeta1")

--- a/testing/GaussFermi_float128.py
+++ b/testing/GaussFermi_float128.py
@@ -2,17 +2,17 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-#Purpose: Fermi integral and inverse
+# Purpose: Fermi integral and inverse
 
 import devsim
 import sys
 
-if not devsim.get_parameter(name='info')['extended_precision']:
+if not devsim.get_parameter(name="info")["extended_precision"]:
     print("Extended precision support is not available with this version")
     sys.exit(0)
 
-devsim.set_parameter(name = "extended_solver", value=True)
-devsim.set_parameter(name = "extended_model", value=True)
-devsim.set_parameter(name = "extended_equation", value=True)
+devsim.set_parameter(name="extended_solver", value=True)
+devsim.set_parameter(name="extended_model", value=True)
+devsim.set_parameter(name="extended_equation", value=True)
 
-import GaussFermi
+import GaussFermi  # noqa: E402, F401

--- a/testing/cap2.py
+++ b/testing/cap2.py
@@ -6,28 +6,75 @@
 #### cap2.py
 #### tests physics of cap made of two insulating regions
 ####
-from devsim import add_1d_contact, add_1d_interface, add_1d_mesh_line, add_1d_region, contact_equation, create_1d_mesh, create_device, delete_contact_equation, delete_edge_model, delete_equation, delete_interface_equation, delete_interface_model, delete_node_model, edge_from_node_model, edge_model, edge_solution, equation, finalize_mesh, get_contact_charge, get_contact_equation_command, get_contact_equation_list, get_contact_list, get_edge_model_values, get_equation_command, get_equation_list, get_interface_equation_command, get_interface_equation_list, get_interface_list, get_node_model_values, get_region_list, interface_equation, interface_model, node_model, node_solution, print_edge_values, print_node_values, set_edge_values, set_node_value, set_node_values, set_parameter, solve
+import array
+from devsim import (
+    add_1d_contact,
+    add_1d_interface,
+    add_1d_mesh_line,
+    add_1d_region,
+    contact_equation,
+    create_1d_mesh,
+    create_device,
+    delete_contact_equation,
+    delete_edge_model,
+    delete_equation,
+    delete_interface_equation,
+    delete_interface_model,
+    delete_node_model,
+    edge_from_node_model,
+    edge_model,
+    edge_solution,
+    equation,
+    finalize_mesh,
+    get_contact_charge,
+    get_contact_equation_command,
+    get_contact_equation_list,
+    get_contact_list,
+    get_edge_model_values,
+    get_equation_command,
+    get_equation_list,
+    get_interface_equation_command,
+    get_interface_equation_list,
+    get_interface_list,
+    get_node_model_values,
+    get_region_list,
+    interface_equation,
+    interface_model,
+    node_model,
+    node_solution,
+    print_edge_values,
+    print_node_values,
+    set_edge_values,
+    set_node_value,
+    set_node_values,
+    set_parameter,
+    solve,
+)
 
-device="MyDevice"
-interface="MySiOx"
-regions =("MyOxRegion", "MySiRegion")
+device = "MyDevice"
+interface = "MySiOx"
+regions = ("MyOxRegion", "MySiRegion")
 
 create_1d_mesh(mesh="cap")
-add_1d_mesh_line(mesh="cap", pos=0,   ps=0.1, tag="top")
+add_1d_mesh_line(mesh="cap", pos=0, ps=0.1, tag="top")
 add_1d_mesh_line(mesh="cap", pos=0.5, ps=0.1, tag="mid")
-add_1d_mesh_line(mesh="cap", pos=1,   ps=0.1, tag="bot")
-add_1d_contact  (mesh="cap", name="top",    tag="top", material="metal")
-add_1d_contact  (mesh="cap", name="bot",    tag="bot", material="metal")
+add_1d_mesh_line(mesh="cap", pos=1, ps=0.1, tag="bot")
+add_1d_contact(mesh="cap", name="top", tag="top", material="metal")
+add_1d_contact(mesh="cap", name="bot", tag="bot", material="metal")
 add_1d_interface(mesh="cap", name="MySiOx", tag="mid")
-add_1d_region   (mesh="cap", material="Si", region="MySiRegion", tag1="top", tag2="mid")
-add_1d_region   (mesh="cap", material="Ox", region="MyOxRegion", tag1="mid", tag2="bot")
+add_1d_region(mesh="cap", material="Si", region="MySiRegion", tag1="top", tag2="mid")
+add_1d_region(mesh="cap", material="Ox", region="MyOxRegion", tag1="mid", tag2="bot")
 finalize_mesh(mesh="cap")
 create_device(mesh="cap", device=device)
 
-set_parameter(device=device, region="MySiRegion", name="Permittivity", value=11.1*8.85e-14)
+set_parameter(
+    device=device, region="MySiRegion", name="Permittivity", value=11.1 * 8.85e-14
+)
 set_parameter(device=device, region="MySiRegion", name="ElectricCharge", value=1.6e-19)
 
-set_parameter(device=device, region="MyOxRegion", name="Permittivity", value=3.9*8.85e-14)
+set_parameter(
+    device=device, region="MyOxRegion", name="Permittivity", value=3.9 * 8.85e-14
+)
 
 set_parameter(device=device, region="MyOxRegion", name="ElectricCharge", value=1.6e-19)
 
@@ -35,52 +82,142 @@ for region in regions:
     node_solution(device=device, region=region, name="Potential")
     edge_from_node_model(device=device, region=region, node_model="Potential")
 
-    edge_model(device=device, region=region, name="ElectricField",
-               equation="(Potential@n0 - Potential@n1)*EdgeInverseLength")
+    edge_model(
+        device=device,
+        region=region,
+        name="ElectricField",
+        equation="(Potential@n0 - Potential@n1)*EdgeInverseLength",
+    )
 
-    edge_model(device=device, region=region, name="ElectricField:Potential@n0",
-               equation="EdgeInverseLength")
+    edge_model(
+        device=device,
+        region=region,
+        name="ElectricField:Potential@n0",
+        equation="EdgeInverseLength",
+    )
 
-    edge_model(device=device, region=region, name="ElectricField:Potential@n1",
-               equation="-EdgeInverseLength")
+    edge_model(
+        device=device,
+        region=region,
+        name="ElectricField:Potential@n1",
+        equation="-EdgeInverseLength",
+    )
 
-    edge_model(device=device, region=region, name="PotentialEdgeFlux", equation="Permittivity*ElectricField")
-    edge_model(device=device, region=region, name="PotentialEdgeFlux:Potential@n0", equation="diff(Permittivity*ElectricField, Potential@n0)")
-    edge_model(device=device, region=region, name="PotentialEdgeFlux:Potential@n1", equation="-PotentialEdgeFlux:Potential@n0")
+    edge_model(
+        device=device,
+        region=region,
+        name="PotentialEdgeFlux",
+        equation="Permittivity*ElectricField",
+    )
+    edge_model(
+        device=device,
+        region=region,
+        name="PotentialEdgeFlux:Potential@n0",
+        equation="diff(Permittivity*ElectricField, Potential@n0)",
+    )
+    edge_model(
+        device=device,
+        region=region,
+        name="PotentialEdgeFlux:Potential@n1",
+        equation="-PotentialEdgeFlux:Potential@n0",
+    )
 
-    equation(device=device, region=region, name="PotentialEquation", variable_name="Potential", node_model="",
-             edge_model="PotentialEdgeFlux", time_node_model="", variable_update="default")
+    equation(
+        device=device,
+        region=region,
+        name="PotentialEquation",
+        variable_name="Potential",
+        node_model="",
+        edge_model="PotentialEdgeFlux",
+        time_node_model="",
+        variable_update="default",
+    )
 
-set_parameter(device=device, region="MySiRegion", name="topbias"   , value=1.0)
+set_parameter(device=device, region="MySiRegion", name="topbias", value=1.0)
 set_parameter(device=device, region="MyOxRegion", name="botbias", value=0.0)
 
 
-conteq="Permittivity*ElectricField"
+conteq = "Permittivity*ElectricField"
 
-node_model(device=device, region="MySiRegion", name="topnode_model",           equation="Potential - topbias")
-node_model(device=device, region="MySiRegion", name="topnode_model:Potential", equation="1")
-edge_model(device=device, region="MySiRegion", name="contactcharge_edge_top",  equation=conteq)
+node_model(
+    device=device,
+    region="MySiRegion",
+    name="topnode_model",
+    equation="Potential - topbias",
+)
+node_model(
+    device=device, region="MySiRegion", name="topnode_model:Potential", equation="1"
+)
+edge_model(
+    device=device, region="MySiRegion", name="contactcharge_edge_top", equation=conteq
+)
 
-node_model(device=device, region="MyOxRegion", name="botnode_model",           equation="Potential - botbias")
-node_model(device=device, region="MyOxRegion", name="botnode_model:Potential", equation="1")
-edge_model(device=device, region="MyOxRegion", name="contactcharge_edge_bottom",  equation=conteq)
+node_model(
+    device=device,
+    region="MyOxRegion",
+    name="botnode_model",
+    equation="Potential - botbias",
+)
+node_model(
+    device=device, region="MyOxRegion", name="botnode_model:Potential", equation="1"
+)
+edge_model(
+    device=device,
+    region="MyOxRegion",
+    name="contactcharge_edge_bottom",
+    equation=conteq,
+)
 
-contact_equation(device=device, contact="top", name="PotentialEquation",
-                 node_model="topnode_model", edge_model="",
-                 node_charge_model="", edge_charge_model="contactcharge_edge_top",
-                 node_current_model="",   edge_current_model="")
+contact_equation(
+    device=device,
+    contact="top",
+    name="PotentialEquation",
+    node_model="topnode_model",
+    edge_model="",
+    node_charge_model="",
+    edge_charge_model="contactcharge_edge_top",
+    node_current_model="",
+    edge_current_model="",
+)
 
-contact_equation(device=device, contact="bot", name="PotentialEquation",
-                 node_model="botnode_model", edge_model="",
-                 node_charge_model="", edge_charge_model="contactcharge_edge_bottom",
-                 node_current_model="", edge_current_model="")
+contact_equation(
+    device=device,
+    contact="bot",
+    name="PotentialEquation",
+    node_model="botnode_model",
+    edge_model="",
+    node_charge_model="",
+    edge_charge_model="contactcharge_edge_bottom",
+    node_current_model="",
+    edge_current_model="",
+)
 
 # type continuous means that regular equations in both regions are swapped into the primary region
-interface_model(device=device, interface=interface, name="continuousPotential", equation="Potential@r0-Potential@r1")
-interface_model(device=device, interface=interface, name="continuousPotential:Potential@r0", equation= "1")
-interface_model(device=device, interface=interface, name="continuousPotential:Potential@r1", equation="-1")
-interface_equation(device=device, interface=interface, name="PotentialEquation", interface_model="continuousPotential", type="continuous")
-
+interface_model(
+    device=device,
+    interface=interface,
+    name="continuousPotential",
+    equation="Potential@r0-Potential@r1",
+)
+interface_model(
+    device=device,
+    interface=interface,
+    name="continuousPotential:Potential@r0",
+    equation="1",
+)
+interface_model(
+    device=device,
+    interface=interface,
+    name="continuousPotential:Potential@r1",
+    equation="-1",
+)
+interface_equation(
+    device=device,
+    interface=interface,
+    name="PotentialEquation",
+    interface_model="continuousPotential",
+    type="continuous",
+)
 
 
 solve(type="dc", absolute_error=1.0, relative_error=1e-10, maximum_iterations=30)
@@ -90,8 +227,12 @@ print((get_contact_charge(device=device, contact="bot", equation="PotentialEquat
 
 print_edge_values(device=device, region="MySiRegion", name="PotentialEdgeFlux")
 print_edge_values(device=device, region="MyOxRegion", name="PotentialEdgeFlux")
-set_parameter(device=device, region="MySiRegion", name="Permittivity", value=1.0*8.85e-14)
-set_parameter(device=device, region="MyOxRegion", name="Permittivity", value=1.0*8.85e-14)
+set_parameter(
+    device=device, region="MySiRegion", name="Permittivity", value=1.0 * 8.85e-14
+)
+set_parameter(
+    device=device, region="MyOxRegion", name="Permittivity", value=1.0 * 8.85e-14
+)
 print_edge_values(device=device, region="MySiRegion", name="PotentialEdgeFlux")
 print_edge_values(device=device, region="MyOxRegion", name="PotentialEdgeFlux")
 
@@ -101,9 +242,13 @@ print_edge_values(device=device, region="MyOxRegion", name="PotentialEdgeFlux")
 print((get_contact_charge(device=device, contact="top", equation="PotentialEquation")))
 print((get_contact_charge(device=device, contact="bot", equation="PotentialEquation")))
 
-set_parameter(device=device, name="Permittivity", value=11.1*8.85e-14)
-set_parameter(device=device, region="MySiRegion", name="Permittivity", value=11.1*8.85e-14)
-set_parameter(device=device, region="MyOxRegion", name="Permittivity", value=3.9*8.85e-14)
+set_parameter(device=device, name="Permittivity", value=11.1 * 8.85e-14)
+set_parameter(
+    device=device, region="MySiRegion", name="Permittivity", value=11.1 * 8.85e-14
+)
+set_parameter(
+    device=device, region="MyOxRegion", name="Permittivity", value=3.9 * 8.85e-14
+)
 
 solve(type="dc", absolute_error=1.0, relative_error=1e-10, maximum_iterations=30)
 print_edge_values(device=device, region="MySiRegion", name="PotentialEdgeFlux")
@@ -114,7 +259,6 @@ print_node_values(device=device, region="MySiRegion", name="Potential")
 print_node_values(device=device, region="MyOxRegion", name="Potential")
 print((get_contact_charge(device=device, contact="top", equation="PotentialEquation")))
 print((get_contact_charge(device=device, contact="bot", equation="PotentialEquation")))
-
 
 
 def get_rlist():
@@ -128,6 +272,7 @@ def get_rlist():
             rlist.append(get_equation_command(device=device, region=r, name=e))
     return rlist
 
+
 def get_clist():
     clist = []
     for c in get_contact_list(device=device):
@@ -138,6 +283,7 @@ def get_clist():
             print("Options: " + str(cmd))
             clist.append(cmd)
     return clist
+
 
 def get_ilist():
     ilist = []
@@ -150,6 +296,7 @@ def get_ilist():
             ilist.append(cmd)
     return ilist
 
+
 rl = get_rlist()
 cl = get_clist()
 il = get_ilist()
@@ -158,17 +305,19 @@ print()
 print()
 
 for i in rl:
-    delete_equation(device=i['device'], region=i['region'], name=i['name'])
+    delete_equation(device=i["device"], region=i["region"], name=i["name"])
 for i in il:
-    delete_interface_equation(device=i['device'], interface=i['interface'], name=i['name'])
+    delete_interface_equation(
+        device=i["device"], interface=i["interface"], name=i["name"]
+    )
 for i in cl:
-    delete_contact_equation(device=i['device'], contact=i['contact'], name=i['name'])
+    delete_contact_equation(device=i["device"], contact=i["contact"], name=i["name"])
 
 get_rlist()
 get_clist()
 get_ilist()
 
-#solve(type="dc", absolute_error=1.0, relative_error=1e-10, maximum_iterations=30)
+# solve(type="dc", absolute_error=1.0, relative_error=1e-10, maximum_iterations=30)
 
 for r in rl:
     equation(**r)
@@ -187,7 +336,9 @@ set_node_value(device=device, region="MySiRegion", name="Potential", value=1.1)
 print(get_node_model_values(device=device, region="MySiRegion", name="Potential"))
 set_node_value(device=device, region="MySiRegion", name="Potential", value=0, index=3)
 print(get_node_model_values(device=device, region="MySiRegion", name="Potential"))
-set_node_values(device=device, region="MySiRegion", name="Potential", init_from="testing")
+set_node_values(
+    device=device, region="MySiRegion", name="Potential", init_from="testing"
+)
 print(get_node_model_values(device=device, region="MySiRegion", name="Potential"))
 set_node_values(device=device, region="MySiRegion", name="Potential", values=nv)
 print(get_node_model_values(device=device, region="MySiRegion", name="Potential"))
@@ -197,21 +348,27 @@ solve(type="dc", absolute_error=1.0, relative_error=1e-10, maximum_iterations=30
 print_edge_values(device=device, region="MySiRegion", name="ElectricField")
 edge_solution(device=device, region="MySiRegion", name="testcopy1")
 print_edge_values(device=device, region="MySiRegion", name="testcopy1")
-set_edge_values(device=device, region="MySiRegion", name="testcopy1", init_from="ElectricField")
+set_edge_values(
+    device=device, region="MySiRegion", name="testcopy1", init_from="ElectricField"
+)
 print_edge_values(device=device, region="MySiRegion", name="testcopy1")
 v = list(get_edge_model_values(device=device, region="MySiRegion", name="testcopy1"))
 v[0] = -1
 v[-1] = +2
 set_edge_values(device=device, region="MySiRegion", name="testcopy1", values=v)
 print_edge_values(device=device, region="MySiRegion", name="testcopy1")
-edge_model(device=device, region="MySiRegion", name="testcopy2", equation="ElectricField-testcopy1")
+edge_model(
+    device=device,
+    region="MySiRegion",
+    name="testcopy2",
+    equation="ElectricField-testcopy1",
+)
 print_edge_values(device=device, region="MySiRegion", name="testcopy2")
 
-delete_edge_model(device=device, region="MySiRegion", name='ElectricField')
-delete_node_model(device=device, region="MySiRegion", name='Potential')
+delete_edge_model(device=device, region="MySiRegion", name="ElectricField")
+delete_node_model(device=device, region="MySiRegion", name="Potential")
 delete_interface_model(device=device, interface=interface, name="continuousPotential")
 
-import array
 x = get_node_model_values(device=device, region="MySiRegion", name="testing")
 print(x)
 x[0] = 1
@@ -219,16 +376,16 @@ print(x)
 set_node_values(device=device, region="MySiRegion", name="testing", values=x)
 set_node_values(device=device, region="MySiRegion", name="testing", values=list(x))
 x = get_node_model_values(device=device, region="MySiRegion", name="testing")
-x[1]=2
+x[1] = 2
 print(x)
 set_node_values(device=device, region="MySiRegion", name="testing", values=x.tobytes())
 x = get_node_model_values(device=device, region="MySiRegion", name="testing")
-x=b'\x00' * 8 * 6
+x = b"\x00" * 8 * 6
 print(x)
 set_node_values(device=device, region="MySiRegion", name="testing", values=x)
 x = get_node_model_values(device=device, region="MySiRegion", name="testing")
 print(x)
-x=array.array('i', [-1]*6)
+x = array.array("i", [-1] * 6)
 print(x)
 set_node_values(device=device, region="MySiRegion", name="testing", values=x)
 x = get_node_model_values(device=device, region="MySiRegion", name="testing")
@@ -237,14 +394,13 @@ x = x.tobytes()
 print(x)
 x = get_node_model_values(device=device, region="MySiRegion", name="testing")
 print(x)
-x = array.array('i', b'\x01\x00\x00\x00' * 6)
+x = array.array("i", b"\x01\x00\x00\x00" * 6)
 print(x)
 set_node_values(device=device, region="MySiRegion", name="testing", values=x)
 x = get_node_model_values(device=device, region="MySiRegion", name="testing")
 print(x)
-x = array.array('Q', b'\x01\x00\x00\x00\x00\x00\x00\x00' * 6)
+x = array.array("Q", b"\x01\x00\x00\x00\x00\x00\x00\x00" * 6)
 print(x)
 set_node_values(device=device, region="MySiRegion", name="testing", values=x.tobytes())
 x = get_node_model_values(device=device, region="MySiRegion", name="testing")
 print(x)
-

--- a/testing/cap_mesh.py
+++ b/testing/cap_mesh.py
@@ -2,23 +2,32 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from devsim import add_1d_contact, add_1d_mesh_line, add_1d_region, create_1d_mesh, finalize_mesh
+from devsim import (
+    add_1d_contact,
+    add_1d_mesh_line,
+    add_1d_region,
+    create_1d_mesh,
+    finalize_mesh,
+)
+
 
 def cap_mesh(region_name, material_name):
-    '''
-      Creates a simple cap mesh named cap1 for test purposes with a given region name
-      Contacts, top, bot
-      length 1.0
-      material "Ox"
-      mesh can be instantiated as a device
-    '''
+    """
+    Creates a simple cap mesh named cap1 for test purposes with a given region name
+    Contacts, top, bot
+    length 1.0
+    material "Ox"
+    mesh can be instantiated as a device
+    """
     create_1d_mesh(mesh="cap1")
     for p, s, t in ((0.0, 0.1, "top"), (1.0, 0.1, "bot")):
-        add_1d_mesh_line(mesh = "cap1", pos=p, ps = s, tag = t)
+        add_1d_mesh_line(mesh="cap1", pos=p, ps=s, tag=t)
 
-    for t in ('top', 'bot'):
-        add_1d_contact(  mesh = "cap1", name=t, tag=t, material="metal")
+    for t in ("top", "bot"):
+        add_1d_contact(mesh="cap1", name=t, tag=t, material="metal")
 
-    add_1d_region(   mesh = "cap1", material=material_name, region=region_name, tag1 ="top" , tag2 = "bot")
+    add_1d_region(
+        mesh="cap1", material=material_name, region=region_name, tag1="top", tag2="bot"
+    )
     finalize_mesh(mesh="cap1")
     return "cap1"

--- a/testing/circ1.py
+++ b/testing/circ1.py
@@ -9,8 +9,8 @@
 import devsim
 import test_common
 
-devices=("MyDevice1", "MyDevice2")
-region="MyRegion"
+devices = ("MyDevice1", "MyDevice2")
+region = "MyRegion"
 
 ####
 #### Meshing
@@ -29,11 +29,19 @@ devsim.circuit_element(name="R1", n1="cnode1", n2=0, value=1e15)
 devsim.set_parameter(device="MyDevice1", name="topbias", value=0.0)
 devsim.set_parameter(device="MyDevice2", name="botbias", value=0.0)
 
-test_common.SetupInitialResistorContact(device="MyDevice1", contact="top", use_circuit_bias=False)
-test_common.SetupInitialResistorContact(device="MyDevice1", contact="bot", use_circuit_bias=True, circuit_node="cnode1")
+test_common.SetupInitialResistorContact(
+    device="MyDevice1", contact="top", use_circuit_bias=False
+)
+test_common.SetupInitialResistorContact(
+    device="MyDevice1", contact="bot", use_circuit_bias=True, circuit_node="cnode1"
+)
 
-test_common.SetupInitialResistorContact(device="MyDevice2", contact="top", use_circuit_bias=True, circuit_node="cnode1")
-test_common.SetupInitialResistorContact(device="MyDevice2", contact="bot", use_circuit_bias=False)
+test_common.SetupInitialResistorContact(
+    device="MyDevice2", contact="top", use_circuit_bias=True, circuit_node="cnode1"
+)
+test_common.SetupInitialResistorContact(
+    device="MyDevice2", contact="bot", use_circuit_bias=False
+)
 
 devsim.solve(type="dc", absolute_error=1.0, relative_error=1e-14, maximum_iterations=30)
 
@@ -45,18 +53,27 @@ for device in devices:
 for device in devices:
     test_common.SetupCarrierResistorSystem(device=device, region=region)
 
-test_common.SetupCarrierResistorContact(device="MyDevice1", contact="top", use_circuit_bias=False)
-test_common.SetupCarrierResistorContact(device="MyDevice1", contact="bot", use_circuit_bias=True, circuit_node="cnode1")
+test_common.SetupCarrierResistorContact(
+    device="MyDevice1", contact="top", use_circuit_bias=False
+)
+test_common.SetupCarrierResistorContact(
+    device="MyDevice1", contact="bot", use_circuit_bias=True, circuit_node="cnode1"
+)
 
-test_common.SetupCarrierResistorContact(device="MyDevice2", contact="top", use_circuit_bias=True, circuit_node="cnode1")
-test_common.SetupCarrierResistorContact(device="MyDevice2", contact="bot", use_circuit_bias=False)
+test_common.SetupCarrierResistorContact(
+    device="MyDevice2", contact="top", use_circuit_bias=True, circuit_node="cnode1"
+)
+test_common.SetupCarrierResistorContact(
+    device="MyDevice2", contact="bot", use_circuit_bias=False
+)
 
 for v in (0.0, 0.01, 0.02, 0.03, 0.04, 0.05, 0.06, 0.07, 0.08, 0.09, 0.10):
     print("topbias %f" % v)
     devsim.set_parameter(device="MyDevice1", name="topbias", value=v)
-    devsim.solve(type="dc", absolute_error=1, relative_error=1e-9, maximum_iterations=30)
+    devsim.solve(
+        type="dc", absolute_error=1, relative_error=1e-9, maximum_iterations=30
+    )
     test_common.print_circuit_solution()
     for device in devices:
         test_common.printResistorCurrent(device=device, contact="top")
         test_common.printResistorCurrent(device=device, contact="bot")
-

--- a/testing/circ2.py
+++ b/testing/circ2.py
@@ -9,8 +9,8 @@
 import devsim
 import test_common
 
-devices=("MyDevice1", "MyDevice2")
-region="MyRegion"
+devices = ("MyDevice1", "MyDevice2")
+region = "MyRegion"
 
 ####
 #### Meshing
@@ -29,11 +29,19 @@ devsim.circuit_element(name="R1", n1="cnode1", n2=0, value=1e15)
 devsim.set_parameter(device="MyDevice1", name="topbias", value=0.0)
 devsim.set_parameter(device="MyDevice2", name="botbias", value=0.0)
 
-test_common.SetupInitialResistorContact(device="MyDevice1", contact="top", use_circuit_bias=True, circuit_node="cnode1")
-test_common.SetupInitialResistorContact(device="MyDevice1", contact="bot", use_circuit_bias=False, circuit_node="topbias")
+test_common.SetupInitialResistorContact(
+    device="MyDevice1", contact="top", use_circuit_bias=True, circuit_node="cnode1"
+)
+test_common.SetupInitialResistorContact(
+    device="MyDevice1", contact="bot", use_circuit_bias=False, circuit_node="topbias"
+)
 
-test_common.SetupInitialResistorContact(device="MyDevice2", contact="top", use_circuit_bias=True, circuit_node="cnode1")
-test_common.SetupInitialResistorContact(device="MyDevice2", contact="bot", use_circuit_bias=False)
+test_common.SetupInitialResistorContact(
+    device="MyDevice2", contact="top", use_circuit_bias=True, circuit_node="cnode1"
+)
+test_common.SetupInitialResistorContact(
+    device="MyDevice2", contact="bot", use_circuit_bias=False
+)
 
 devsim.solve(type="dc", absolute_error=1.0, relative_error=1e-14, maximum_iterations=30)
 
@@ -45,18 +53,27 @@ for device in devices:
 for device in devices:
     test_common.SetupCarrierResistorSystem(device=device, region=region)
 
-test_common.SetupCarrierResistorContact(device="MyDevice1", contact="top", use_circuit_bias=True, circuit_node="cnode1")
-test_common.SetupCarrierResistorContact(device="MyDevice1", contact="bot", use_circuit_bias=False, circuit_node="topbias")
+test_common.SetupCarrierResistorContact(
+    device="MyDevice1", contact="top", use_circuit_bias=True, circuit_node="cnode1"
+)
+test_common.SetupCarrierResistorContact(
+    device="MyDevice1", contact="bot", use_circuit_bias=False, circuit_node="topbias"
+)
 
-test_common.SetupCarrierResistorContact(device="MyDevice2", contact="top", use_circuit_bias=True, circuit_node="cnode1")
-test_common.SetupCarrierResistorContact(device="MyDevice2", contact="bot", use_circuit_bias=False)
+test_common.SetupCarrierResistorContact(
+    device="MyDevice2", contact="top", use_circuit_bias=True, circuit_node="cnode1"
+)
+test_common.SetupCarrierResistorContact(
+    device="MyDevice2", contact="bot", use_circuit_bias=False
+)
 
 for v in (0.0, 0.01, 0.02, 0.03, 0.04, 0.05, 0.06, 0.07, 0.08, 0.09, 0.10):
     print("topbias %f" % v)
     devsim.set_parameter(device="MyDevice1", name="topbias", value=v)
-    devsim.solve(type="dc", absolute_error=1, relative_error=1e-9, maximum_iterations=30)
+    devsim.solve(
+        type="dc", absolute_error=1, relative_error=1e-9, maximum_iterations=30
+    )
     test_common.print_circuit_solution()
     for device in devices:
         test_common.printResistorCurrent(device=device, contact="top")
         test_common.printResistorCurrent(device=device, contact="bot")
-

--- a/testing/circ3.py
+++ b/testing/circ3.py
@@ -16,4 +16,3 @@ test_common.print_circuit_solution()
 devsim.circuit_alter(name="V1", value=2.0)
 devsim.solve(type="dc", absolute_error=1.0, relative_error=1e-14, maximum_iterations=3)
 test_common.print_circuit_solution()
-

--- a/testing/circ4.py
+++ b/testing/circ4.py
@@ -9,8 +9,8 @@
 import devsim
 import test_common
 
-devices=("MyDevice1", "MyDevice2")
-region="MyRegion"
+devices = ("MyDevice1", "MyDevice2")
+region = "MyRegion"
 
 ####
 #### Meshing
@@ -27,17 +27,36 @@ devsim.add_circuit_node(name="cnode1", variable_update="default")
 devsim.circuit_element(name="R1", n1="cnode1", n2=0, value=1e15)
 devsim.circuit_element(name="V1", n1="cnode0", n2=0, value=0.0)
 
-test_common.SetupInitialResistorContact(device="MyDevice1", contact="top", use_circuit_bias=True, circuit_node="MyDevice1_top")
-test_common.SetupInitialResistorContact(device="MyDevice1", contact="bot", use_circuit_bias=True, circuit_node="MyDevice1_bot")
-test_common.SetupInitialResistorContact(device="MyDevice2", contact="top", use_circuit_bias=True, circuit_node="MyDevice2_top")
-test_common.SetupInitialResistorContact(device="MyDevice2", contact="bot", use_circuit_bias=True, circuit_node="MyDevice2_bot")
-
+test_common.SetupInitialResistorContact(
+    device="MyDevice1",
+    contact="top",
+    use_circuit_bias=True,
+    circuit_node="MyDevice1_top",
+)
+test_common.SetupInitialResistorContact(
+    device="MyDevice1",
+    contact="bot",
+    use_circuit_bias=True,
+    circuit_node="MyDevice1_bot",
+)
+test_common.SetupInitialResistorContact(
+    device="MyDevice2",
+    contact="top",
+    use_circuit_bias=True,
+    circuit_node="MyDevice2_top",
+)
+test_common.SetupInitialResistorContact(
+    device="MyDevice2",
+    contact="bot",
+    use_circuit_bias=True,
+    circuit_node="MyDevice2_bot",
+)
 
 
 devsim.circuit_node_alias(node="cnode0", alias="MyDevice1_top")
 devsim.circuit_node_alias(node="cnode1", alias="MyDevice2_top")
 devsim.circuit_node_alias(node="cnode1", alias="MyDevice1_bot")
-devsim.circuit_node_alias(node="GND",    alias="MyDevice2_bot")
+devsim.circuit_node_alias(node="GND", alias="MyDevice2_bot")
 
 devsim.solve(type="dc", absolute_error=1.0, relative_error=1e-14, maximum_iterations=30)
 
@@ -49,18 +68,38 @@ for device in devices:
 for device in devices:
     test_common.SetupCarrierResistorSystem(device=device, region=region)
 
-test_common.SetupCarrierResistorContact(device="MyDevice1", contact="top", use_circuit_bias=True, circuit_node="MyDevice1_top")
-test_common.SetupCarrierResistorContact(device="MyDevice1", contact="bot", use_circuit_bias=True, circuit_node="MyDevice1_bot")
-test_common.SetupCarrierResistorContact(device="MyDevice2", contact="top", use_circuit_bias=True, circuit_node="MyDevice2_top")
-test_common.SetupCarrierResistorContact(device="MyDevice2", contact="bot", use_circuit_bias=True, circuit_node="MyDevice2_bot")
-
+test_common.SetupCarrierResistorContact(
+    device="MyDevice1",
+    contact="top",
+    use_circuit_bias=True,
+    circuit_node="MyDevice1_top",
+)
+test_common.SetupCarrierResistorContact(
+    device="MyDevice1",
+    contact="bot",
+    use_circuit_bias=True,
+    circuit_node="MyDevice1_bot",
+)
+test_common.SetupCarrierResistorContact(
+    device="MyDevice2",
+    contact="top",
+    use_circuit_bias=True,
+    circuit_node="MyDevice2_top",
+)
+test_common.SetupCarrierResistorContact(
+    device="MyDevice2",
+    contact="bot",
+    use_circuit_bias=True,
+    circuit_node="MyDevice2_bot",
+)
 
 
 for v in (0.0, 0.01, 0.02, 0.03, 0.04, 0.05, 0.06, 0.07, 0.08, 0.09, 0.10):
     devsim.circuit_alter(name="V1", value=v)
-    devsim.solve(type="dc", absolute_error=1.0, relative_error=1e-9, maximum_iterations=30)
+    devsim.solve(
+        type="dc", absolute_error=1.0, relative_error=1e-9, maximum_iterations=30
+    )
     test_common.print_circuit_solution()
     for device in devices:
         test_common.printResistorCurrent(device=device, contact="top")
         test_common.printResistorCurrent(device=device, contact="bot")
-

--- a/testing/dio2_element_2d.py
+++ b/testing/dio2_element_2d.py
@@ -13,34 +13,54 @@ import dio2_element_physics
 # in dio2 add recombination
 #
 
+
 ####
 #### Meshing
 ####
 def createMesh(device, region):
-    devsim.create_2d_mesh  (mesh="dog")
-    devsim.add_2d_mesh_line(mesh="dog", dir="x", pos=0     , ps=1e-6)
+    devsim.create_2d_mesh(mesh="dog")
+    devsim.add_2d_mesh_line(mesh="dog", dir="x", pos=0, ps=1e-6)
     devsim.add_2d_mesh_line(mesh="dog", dir="x", pos=0.5e-5, ps=1e-8)
-    devsim.add_2d_mesh_line(mesh="dog", dir="x", pos=1e-5  , ps=1e-6)
-    devsim.add_2d_mesh_line(mesh="dog", dir="y", pos=0     , ps=1e-6)
-    devsim.add_2d_mesh_line(mesh="dog", dir="y", pos=1e-5  , ps=1e-6)
+    devsim.add_2d_mesh_line(mesh="dog", dir="x", pos=1e-5, ps=1e-6)
+    devsim.add_2d_mesh_line(mesh="dog", dir="y", pos=0, ps=1e-6)
+    devsim.add_2d_mesh_line(mesh="dog", dir="y", pos=1e-5, ps=1e-6)
 
-    devsim.add_2d_mesh_line(mesh="dog", dir="x", pos=-1e-8   , ps=1e-8)
+    devsim.add_2d_mesh_line(mesh="dog", dir="x", pos=-1e-8, ps=1e-8)
     devsim.add_2d_mesh_line(mesh="dog", dir="x", pos=1.001e-5, ps=1e-8)
 
-    devsim.add_2d_region   (mesh="dog", material="Si", region=region)
-    devsim.add_2d_region   (mesh="dog", material="Si", region="air1", xl=-1e-8,  xh=0)
-    devsim.add_2d_region   (mesh="dog", material="Si", region="air2", xl=1.0e-5, xh=1.001e-5)
+    devsim.add_2d_region(mesh="dog", material="Si", region=region)
+    devsim.add_2d_region(mesh="dog", material="Si", region="air1", xl=-1e-8, xh=0)
+    devsim.add_2d_region(
+        mesh="dog", material="Si", region="air2", xl=1.0e-5, xh=1.001e-5
+    )
 
-    devsim.add_2d_contact  (mesh="dog", name="top", region=region, yl=0.8e-5, yh=1e-5, xl=0, xh=0, bloat=1e-10, material="metal")
-    devsim.add_2d_contact  (mesh="dog", name="bot", region=region, xl=1e-5,   xh=1e-5, bloat=1e-10, material="metal")
+    devsim.add_2d_contact(
+        mesh="dog",
+        name="top",
+        region=region,
+        yl=0.8e-5,
+        yh=1e-5,
+        xl=0,
+        xh=0,
+        bloat=1e-10,
+        material="metal",
+    )
+    devsim.add_2d_contact(
+        mesh="dog",
+        name="bot",
+        region=region,
+        xl=1e-5,
+        xh=1e-5,
+        bloat=1e-10,
+        material="metal",
+    )
 
-    devsim.finalize_mesh   (mesh="dog")
-    devsim.create_device   (mesh="dog", device=device)
+    devsim.finalize_mesh(mesh="dog")
+    devsim.create_device(mesh="dog", device=device)
 
 
-
-device="MyDevice"
-region="MyRegion"
+device = "MyDevice"
+region = "MyRegion"
 
 createMesh(device, region)
 
@@ -53,8 +73,8 @@ dio2_element_physics.createSolution(device, region, "Potential")
 ####
 for name, equation in (
     ("Acceptors", "1.0e18*step(0.5e-5-x)"),
-  ("Donors",    "1.0e18*step(x-0.5e-5)"),
-  ("NetDoping", "Donors-Acceptors"),
+    ("Donors", "1.0e18*step(x-0.5e-5)"),
+    ("NetDoping", "Donors-Acceptors"),
 ):
     devsim.node_model(device=device, region=region, name=name, equation=equation)
 
@@ -80,8 +100,12 @@ dio2_element_physics.createSolution(device, region, "Holes")
 ####
 #### create initial guess from dc only solution
 ####
-devsim.set_node_values(device=device, region=region, name="Electrons", init_from="IntrinsicElectrons")
-devsim.set_node_values(device=device, region=region, name="Holes",     init_from="IntrinsicHoles")
+devsim.set_node_values(
+    device=device, region=region, name="Electrons", init_from="IntrinsicElectrons"
+)
+devsim.set_node_values(
+    device=device, region=region, name="Holes", init_from="IntrinsicHoles"
+)
 
 dio2_element_physics.createDriftDiffusion(device, region)
 
@@ -89,24 +113,24 @@ dio2_element_physics.createDriftDiffusionAtContact(device, region, "top")
 dio2_element_physics.createDriftDiffusionAtContact(device, region, "bot")
 
 
-
 devsim.set_parameter(device=device, region=region, name="topbias", value=0.0)
 
 #
 # This is to test the solution backup
 #
-#set_parameter -device device -region region -name "topbias" -value 10
-#catch {solve -type dc -absolute_error 1e10 -relative_error 1e-10 -maximum_iterations 30} x
-#puts x
+# set_parameter -device device -region region -name "topbias" -value 10
+# catch {solve -type dc -absolute_error 1e10 -relative_error 1e-10 -maximum_iterations 30} x
+# puts x
 
-v=0
+v = 0
 while v < 0.51:
     devsim.set_parameter(device=device, region=region, name="topbias", value=v)
-    devsim.solve(type="dc", absolute_error=1e10, relative_error=1e-10, maximum_iterations=30)
+    devsim.solve(
+        type="dc", absolute_error=1e10, relative_error=1e-10, maximum_iterations=30
+    )
     dio2_element_physics.printCurrents(device, "top", v)
     dio2_element_physics.printCurrents(device, "bot", 0.0)
     v += 0.1
 
 devsim.write_devices(file="dio2_element_2d_dd.flps", type="floops")
 devsim.write_devices(file="dio2_element_2d_dd", type="vtk")
-

--- a/testing/dio2_element_physics.py
+++ b/testing/dio2_element_physics.py
@@ -8,209 +8,295 @@ import devsim
 ### element edge based example
 ###
 
+
 def printCurrents(device, contact, bias):
-    ecurr=devsim.get_contact_current(contact=contact, equation="ElectronContinuityEquation", device=device)
-    hcurr=devsim.get_contact_current(contact=contact, equation="HoleContinuityEquation", device=device)
+    ecurr = devsim.get_contact_current(
+        contact=contact, equation="ElectronContinuityEquation", device=device
+    )
+    hcurr = devsim.get_contact_current(
+        contact=contact, equation="HoleContinuityEquation", device=device
+    )
     tcurr = ecurr + hcurr
     print("%s %g %g %g %g" % (contact, bias, ecurr, hcurr, tcurr))
+
 
 ####
 #### Constants
 ####
 def setMaterialParameters(device, region):
-    q=1.6e-19
-    k=1.3806503e-23
-    eps=8.85e-14
-    T=300
+    q = 1.6e-19
+    k = 1.3806503e-23
+    eps = 8.85e-14
+    T = 300
     for name, value in (
-        ("Permittivity", 11.1*eps),
-      ("ElectronCharge", q),
-      ("n_i", 1.0e10),
-      ("kT", eps * T),
-      ("V_t", k*T/q),
-      ("mu_n", 400),
-      ("mu_p", 200),
+        ("Permittivity", 11.1 * eps),
+        ("ElectronCharge", q),
+        ("n_i", 1.0e10),
+        ("kT", eps * T),
+        ("V_t", k * T / q),
+        ("mu_n", 400),
+        ("mu_p", 200),
     ):
         devsim.set_parameter(device=device, region=region, name=name, value=value)
+
 
 def createSolution(device, region, name):
     devsim.node_solution(device=device, region=region, name=name)
     devsim.edge_from_node_model(device=device, region=region, node_model=name)
 
+
 def createPotentialOnly(device, region):
     for name, equation in (
-        ("IntrinsicElectrons",                     "n_i*exp(Potential/V_t)"),
-      ("IntrinsicElectrons:Potential",           "diff(n_i*exp(Potential/V_t), Potential)"),
-      ("IntrinsicHoles",                         "n_i^2/IntrinsicElectrons"),
-      ("IntrinsicHoles:Potential",               "diff(n_i^2/IntrinsicElectrons, Potential)"),
-      ("IntrinsicCharge",                        "IntrinsicHoles-IntrinsicElectrons + NetDoping"),
-      ("IntrinsicCharge:Potential",              "diff(IntrinsicHoles-IntrinsicElectrons, Potential)"),
-      ("PotentialIntrinsicNodeCharge",           "-ElectronCharge*IntrinsicCharge"),
-      ("PotentialIntrinsicNodeCharge:Potential", "diff(-ElectronCharge*IntrinsicCharge, Potential)"),
+        ("IntrinsicElectrons", "n_i*exp(Potential/V_t)"),
+        ("IntrinsicElectrons:Potential", "diff(n_i*exp(Potential/V_t), Potential)"),
+        ("IntrinsicHoles", "n_i^2/IntrinsicElectrons"),
+        ("IntrinsicHoles:Potential", "diff(n_i^2/IntrinsicElectrons, Potential)"),
+        ("IntrinsicCharge", "IntrinsicHoles-IntrinsicElectrons + NetDoping"),
+        (
+            "IntrinsicCharge:Potential",
+            "diff(IntrinsicHoles-IntrinsicElectrons, Potential)",
+        ),
+        ("PotentialIntrinsicNodeCharge", "-ElectronCharge*IntrinsicCharge"),
+        (
+            "PotentialIntrinsicNodeCharge:Potential",
+            "diff(-ElectronCharge*IntrinsicCharge, Potential)",
+        ),
     ):
         devsim.node_model(device=device, region=region, name=name, equation=equation)
 
     for name, equation in (
-        ("EField",              "(Potential@n0-Potential@n1)*EdgeInverseLength"),
-      ("EField:Potential@n0", "EdgeInverseLength"),
-      ("EField:Potential@n1", "-EField:Potential@n0"),
+        ("EField", "(Potential@n0-Potential@n1)*EdgeInverseLength"),
+        ("EField:Potential@n0", "EdgeInverseLength"),
+        ("EField:Potential@n1", "-EField:Potential@n0"),
     ):
         devsim.edge_model(device=device, region=region, name=name, equation=equation)
 
     devsim.element_from_edge_model(edge_model="EField", device=device, region=region)
-    devsim.element_from_edge_model(edge_model="EField", derivative="Potential", device=device, region=region)
+    devsim.element_from_edge_model(
+        edge_model="EField", derivative="Potential", device=device, region=region
+    )
 
-    foo="dot2d(EField_x, EField_y, unitx, unity)"
+    foo = "dot2d(EField_x, EField_y, unitx, unity)"
     for name, equation in (
         ("ElectricField", foo),
-      ("ElectricField:Potential@en0", "diff(%s, Potential@en0)" % foo),
-      ("ElectricField:Potential@en1", "diff(%s, Potential@en1)" % foo),
-      ("ElectricField:Potential@en2", "diff(%s, Potential@en2)" % foo),
-      ("PotentialEdgeFlux", "Permittivity*ElectricField"),
-      ("PotentialEdgeFlux:Potential@en0", "diff(Permittivity*ElectricField,Potential@en0)"),
-      ("PotentialEdgeFlux:Potential@en1", "diff(Permittivity*ElectricField,Potential@en1)"),
-      ("PotentialEdgeFlux:Potential@en2", "diff(Permittivity*ElectricField,Potential@en2)"),
+        ("ElectricField:Potential@en0", "diff(%s, Potential@en0)" % foo),
+        ("ElectricField:Potential@en1", "diff(%s, Potential@en1)" % foo),
+        ("ElectricField:Potential@en2", "diff(%s, Potential@en2)" % foo),
+        ("PotentialEdgeFlux", "Permittivity*ElectricField"),
+        (
+            "PotentialEdgeFlux:Potential@en0",
+            "diff(Permittivity*ElectricField,Potential@en0)",
+        ),
+        (
+            "PotentialEdgeFlux:Potential@en1",
+            "diff(Permittivity*ElectricField,Potential@en1)",
+        ),
+        (
+            "PotentialEdgeFlux:Potential@en2",
+            "diff(Permittivity*ElectricField,Potential@en2)",
+        ),
     ):
         devsim.element_model(device=device, region=region, name=name, equation=equation)
 
-    devsim.equation(device=device, region=region, name="PotentialEquation", variable_name="Potential",
-                    node_model="PotentialIntrinsicNodeCharge", element_model="PotentialEdgeFlux", variable_update="log_damp")
+    devsim.equation(
+        device=device,
+        region=region,
+        name="PotentialEquation",
+        variable_name="Potential",
+        node_model="PotentialIntrinsicNodeCharge",
+        element_model="PotentialEdgeFlux",
+        variable_update="log_damp",
+    )
+
 
 def createPotentialOnlyContact(device, region, contact):
-    format_dict = {"contact" : contact}
+    format_dict = {"contact": contact}
     biasname = contact + "bias"
     devsim.set_parameter(device=device, region=region, name=biasname, value=0.0)
 
     for name, equation in (
-        ("celec_%(contact)s", "1e-10 + 0.5*(NetDoping+(NetDoping^2 + 4 * n_i^2)^(0.5))+1e-10"),
-      ("chole_%(contact)s", "1e-10 + 0.5*(-NetDoping+(NetDoping^2 + 4 * n_i^2)^(0.5))+1e-10"),
-      ("%(contact)snodemodel", '''ifelse(NetDoping > 0,
+        (
+            "celec_%(contact)s",
+            "1e-10 + 0.5*(NetDoping+(NetDoping^2 + 4 * n_i^2)^(0.5))+1e-10",
+        ),
+        (
+            "chole_%(contact)s",
+            "1e-10 + 0.5*(-NetDoping+(NetDoping^2 + 4 * n_i^2)^(0.5))+1e-10",
+        ),
+        (
+            "%(contact)snodemodel",
+            """ifelse(NetDoping > 0,
       Potential-%(contact)sbias-V_t*log(celec_%(contact)s/n_i),
-      Potential-%(contact)sbias+V_t*log(chole_%(contact)s/n_i))'''),
-      ("%(contact)snodemodel:Potential", "1"),
-    ):
-        name_sub     = name % format_dict
-        equation_sub = equation % format_dict
-        devsim.contact_node_model(device=device, contact=contact, name=name_sub, equation=equation_sub)
-
-
-    devsim.contact_equation(device=device, contact=contact, name="PotentialEquation",
-                            node_model="%snodemodel" % contact)
-
-def createDriftDiffusion(device, region):
-    for name, equation in (
-        ("PotentialNodeCharge"          , "-ElectronCharge*(Holes -Electrons + NetDoping)"),
-      ("PotentialNodeCharge:Electrons", "+ElectronCharge"),
-      ("PotentialNodeCharge:Holes"    , "-ElectronCharge"),
-    ):
-        devsim.node_model(device=device, region=region, name=name, equation=equation)
-
-    devsim.equation(device=device, region=region, name="PotentialEquation", variable_name="Potential", node_model="PotentialNodeCharge",
-                    element_model="PotentialEdgeFlux", variable_update="log_damp")
-
-    for name, equation in (
-        ("vdiff"              , "(Potential@n0 - Potential@n1)/V_t"),
-      ("vdiff:Potential@n0" , "V_t^(-1)"),
-      ("vdiff:Potential@n1" , "-V_t^(-1)"),
-      ("Bern01"             , "B(vdiff)"),
-      ("Bern01:Potential@n0", "dBdx(vdiff)*vdiff:Potential@n0"),
-      ("Bern01:Potential@n1", "dBdx(vdiff)*vdiff:Potential@n1"),
-      ("Bern10"             , "Bern01 + vdiff"),
-      ("Bern10:Potential@n0", "Bern01:Potential@n0 + vdiff:Potential@n0"),
-      ("Bern10:Potential@n1", "Bern01:Potential@n1 + vdiff:Potential@n1"),
-    ):
-        devsim.edge_model(device=device, region=region, name=name, equation=equation)
-
-    Jn      ="ElectronCharge*mu_n*EdgeInverseLength*V_t*(Electrons@n1*Bern10 - Electrons@n0*Bern01)"
-    dJndn0  ="simplify(diff( %s, Electrons@n0))" % Jn
-    dJndn1  ="simplify(diff( %s, Electrons@n1))" % Jn
-    dJndpot0="simplify(diff( %s, Potential@n0))" % Jn
-    dJndpot1="simplify(diff( %s, Potential@n1))" % Jn
-    for name, equation in (
-        ("ElectronCurrent"             , Jn),
-      ("ElectronCurrent:Electrons@n0", dJndn0),
-      ("ElectronCurrent:Electrons@n1", dJndn1),
-      ("ElectronCurrent:Potential@n0", dJndpot0),
-      ("ElectronCurrent:Potential@n1", dJndpot1),
-    ):
-        devsim.edge_model(device=device, region=region, name=name, equation=equation)
-
-    Jp      ="-ElectronCharge*mu_p*EdgeInverseLength*V_t*(Holes@n1*Bern01 - Holes@n0*Bern10)"
-    dJpdp0  ="simplify(diff(%s, Holes@n0))" % Jp
-    dJpdp1  ="simplify(diff(%s, Holes@n1))" % Jp
-    dJpdpot0="simplify(diff(%s, Potential@n0))" % Jp
-    dJpdpot1="simplify(diff(%s, Potential@n1))" % Jp
-
-    for name, equation in (
-        ("HoleCurrent"             , Jp),
-      ("HoleCurrent:Holes@n0"    , dJpdp0),
-      ("HoleCurrent:Holes@n1"    , dJpdp1),
-      ("HoleCurrent:Potential@n0", dJpdpot0),
-      ("HoleCurrent:Potential@n1", dJpdpot1),
-    ):
-        devsim.edge_model(device=device, region=region, name=name, equation=equation)
-
-    NCharge="-ElectronCharge * Electrons"
-    dNChargedn="-ElectronCharge"
-    for name, equation in (
-        ("NCharge",           NCharge),
-      ("NCharge:Electrons", dNChargedn),
-    ):
-        devsim.node_model(device=device, region=region, name=name, equation=equation)
-
-    PCharge="-ElectronCharge * Holes"
-    dPChargedp="-ElectronCharge"
-    for name, equation in (
-        ("PCharge", PCharge),
-      ("PCharge:Holes", dPChargedp),
-    ):
-        devsim.node_model(device=device, region=region, name=name, equation=equation)
-
-
-    ni=devsim.get_parameter(device=device, region=region, name="n_i")
-    for name, value in (
-        ("n1", ni),
-      ("p1", ni),
-      ("taun", 1e-5),
-      ("taup", 1e-5),
-    ):
-        devsim.set_parameter(device=device, region=region, name=name, value=value)
-
-    USRH="-ElectronCharge*(Electrons*Holes - n_i^2)/(taup*(Electrons + n1) + taun*(Holes + p1))"
-    dUSRHdn="simplify(diff($USRH, Electrons))"
-    dUSRHdp="simplify(diff($USRH, Holes))"
-    for name, equation in (
-        ("USRH", USRH),
-      ("USRH:Electrons", dUSRHdn),
-      ("USRH:Holes", dUSRHdp),
-    ):
-        devsim.node_model(device=device, region=region, name=name, equation=equation)
-
-    devsim.equation(device=device, region=region, name="ElectronContinuityEquation", variable_name="Electrons",
-                    edge_model="ElectronCurrent", variable_update="positive",
-                    time_node_model="NCharge", node_model="USRH")
-
-    devsim.equation(device=device, region=region, name="HoleContinuityEquation", variable_name="Holes",
-                    edge_model="HoleCurrent", variable_update="positive",
-                    time_node_model="PCharge", node_model="USRH")
-
-def createDriftDiffusionAtContact(device, region, contact):
-    format_dict = {'contact' : contact}
-    for name, equation in (
-        ("%(contact)snodeelectrons"          , "ifelse(NetDoping > 0, Electrons - celec_%(contact)s, Electrons - n_i^2/chole_%(contact)s)"),
-      ("%(contact)snodeholes"              , "ifelse(NetDoping < 0, Holes - chole_%(contact)s, Holes - n_i^2/celec_%(contact)s)"),
-      ("%(contact)snodeelectrons:Electrons", "1.0"),
-      ("%(contact)snodeholes:Holes"        , "1.0"),
+      Potential-%(contact)sbias+V_t*log(chole_%(contact)s/n_i))""",
+        ),
+        ("%(contact)snodemodel:Potential", "1"),
     ):
         name_sub = name % format_dict
         equation_sub = equation % format_dict
-        devsim.contact_node_model(device=device, contact=contact, name=name_sub, equation=equation_sub)
+        devsim.contact_node_model(
+            device=device, contact=contact, name=name_sub, equation=equation_sub
+        )
 
-        devsim.contact_equation(device=device, contact=contact, name="ElectronContinuityEquation",
-                                node_model="%snodeelectrons" % contact,
-                                edge_current_model="ElectronCurrent")
+    devsim.contact_equation(
+        device=device,
+        contact=contact,
+        name="PotentialEquation",
+        node_model="%snodemodel" % contact,
+    )
 
-        devsim.contact_equation(device=device, contact=contact, name="HoleContinuityEquation",
-                                node_model="%snodeholes" % contact,
-                                edge_current_model="HoleCurrent")
 
+def createDriftDiffusion(device, region):
+    for name, equation in (
+        ("PotentialNodeCharge", "-ElectronCharge*(Holes -Electrons + NetDoping)"),
+        ("PotentialNodeCharge:Electrons", "+ElectronCharge"),
+        ("PotentialNodeCharge:Holes", "-ElectronCharge"),
+    ):
+        devsim.node_model(device=device, region=region, name=name, equation=equation)
+
+    devsim.equation(
+        device=device,
+        region=region,
+        name="PotentialEquation",
+        variable_name="Potential",
+        node_model="PotentialNodeCharge",
+        element_model="PotentialEdgeFlux",
+        variable_update="log_damp",
+    )
+
+    for name, equation in (
+        ("vdiff", "(Potential@n0 - Potential@n1)/V_t"),
+        ("vdiff:Potential@n0", "V_t^(-1)"),
+        ("vdiff:Potential@n1", "-V_t^(-1)"),
+        ("Bern01", "B(vdiff)"),
+        ("Bern01:Potential@n0", "dBdx(vdiff)*vdiff:Potential@n0"),
+        ("Bern01:Potential@n1", "dBdx(vdiff)*vdiff:Potential@n1"),
+        ("Bern10", "Bern01 + vdiff"),
+        ("Bern10:Potential@n0", "Bern01:Potential@n0 + vdiff:Potential@n0"),
+        ("Bern10:Potential@n1", "Bern01:Potential@n1 + vdiff:Potential@n1"),
+    ):
+        devsim.edge_model(device=device, region=region, name=name, equation=equation)
+
+    Jn = "ElectronCharge*mu_n*EdgeInverseLength*V_t*(Electrons@n1*Bern10 - Electrons@n0*Bern01)"
+    dJndn0 = "simplify(diff( %s, Electrons@n0))" % Jn
+    dJndn1 = "simplify(diff( %s, Electrons@n1))" % Jn
+    dJndpot0 = "simplify(diff( %s, Potential@n0))" % Jn
+    dJndpot1 = "simplify(diff( %s, Potential@n1))" % Jn
+    for name, equation in (
+        ("ElectronCurrent", Jn),
+        ("ElectronCurrent:Electrons@n0", dJndn0),
+        ("ElectronCurrent:Electrons@n1", dJndn1),
+        ("ElectronCurrent:Potential@n0", dJndpot0),
+        ("ElectronCurrent:Potential@n1", dJndpot1),
+    ):
+        devsim.edge_model(device=device, region=region, name=name, equation=equation)
+
+    Jp = (
+        "-ElectronCharge*mu_p*EdgeInverseLength*V_t*(Holes@n1*Bern01 - Holes@n0*Bern10)"
+    )
+    dJpdp0 = "simplify(diff(%s, Holes@n0))" % Jp
+    dJpdp1 = "simplify(diff(%s, Holes@n1))" % Jp
+    dJpdpot0 = "simplify(diff(%s, Potential@n0))" % Jp
+    dJpdpot1 = "simplify(diff(%s, Potential@n1))" % Jp
+
+    for name, equation in (
+        ("HoleCurrent", Jp),
+        ("HoleCurrent:Holes@n0", dJpdp0),
+        ("HoleCurrent:Holes@n1", dJpdp1),
+        ("HoleCurrent:Potential@n0", dJpdpot0),
+        ("HoleCurrent:Potential@n1", dJpdpot1),
+    ):
+        devsim.edge_model(device=device, region=region, name=name, equation=equation)
+
+    NCharge = "-ElectronCharge * Electrons"
+    dNChargedn = "-ElectronCharge"
+    for name, equation in (
+        ("NCharge", NCharge),
+        ("NCharge:Electrons", dNChargedn),
+    ):
+        devsim.node_model(device=device, region=region, name=name, equation=equation)
+
+    PCharge = "-ElectronCharge * Holes"
+    dPChargedp = "-ElectronCharge"
+    for name, equation in (
+        ("PCharge", PCharge),
+        ("PCharge:Holes", dPChargedp),
+    ):
+        devsim.node_model(device=device, region=region, name=name, equation=equation)
+
+    ni = devsim.get_parameter(device=device, region=region, name="n_i")
+    for name, value in (
+        ("n1", ni),
+        ("p1", ni),
+        ("taun", 1e-5),
+        ("taup", 1e-5),
+    ):
+        devsim.set_parameter(device=device, region=region, name=name, value=value)
+
+    USRH = "-ElectronCharge*(Electrons*Holes - n_i^2)/(taup*(Electrons + n1) + taun*(Holes + p1))"
+    dUSRHdn = "simplify(diff($USRH, Electrons))"
+    dUSRHdp = "simplify(diff($USRH, Holes))"
+    for name, equation in (
+        ("USRH", USRH),
+        ("USRH:Electrons", dUSRHdn),
+        ("USRH:Holes", dUSRHdp),
+    ):
+        devsim.node_model(device=device, region=region, name=name, equation=equation)
+
+    devsim.equation(
+        device=device,
+        region=region,
+        name="ElectronContinuityEquation",
+        variable_name="Electrons",
+        edge_model="ElectronCurrent",
+        variable_update="positive",
+        time_node_model="NCharge",
+        node_model="USRH",
+    )
+
+    devsim.equation(
+        device=device,
+        region=region,
+        name="HoleContinuityEquation",
+        variable_name="Holes",
+        edge_model="HoleCurrent",
+        variable_update="positive",
+        time_node_model="PCharge",
+        node_model="USRH",
+    )
+
+
+def createDriftDiffusionAtContact(device, region, contact):
+    format_dict = {"contact": contact}
+    for name, equation in (
+        (
+            "%(contact)snodeelectrons",
+            "ifelse(NetDoping > 0, Electrons - celec_%(contact)s, Electrons - n_i^2/chole_%(contact)s)",
+        ),
+        (
+            "%(contact)snodeholes",
+            "ifelse(NetDoping < 0, Holes - chole_%(contact)s, Holes - n_i^2/celec_%(contact)s)",
+        ),
+        ("%(contact)snodeelectrons:Electrons", "1.0"),
+        ("%(contact)snodeholes:Holes", "1.0"),
+    ):
+        name_sub = name % format_dict
+        equation_sub = equation % format_dict
+        devsim.contact_node_model(
+            device=device, contact=contact, name=name_sub, equation=equation_sub
+        )
+
+        devsim.contact_equation(
+            device=device,
+            contact=contact,
+            name="ElectronContinuityEquation",
+            node_model="%snodeelectrons" % contact,
+            edge_current_model="ElectronCurrent",
+        )
+
+        devsim.contact_equation(
+            device=device,
+            contact=contact,
+            name="HoleContinuityEquation",
+            node_model="%snodeholes" % contact,
+            edge_current_model="HoleCurrent",
+        )

--- a/testing/equation1.py
+++ b/testing/equation1.py
@@ -2,9 +2,18 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from devsim import add_circuit_node, circuit_alter, circuit_element, custom_equation, get_circuit_equation_number, get_circuit_node_value, solve
+from devsim import (
+    add_circuit_node,
+    circuit_alter,
+    circuit_element,
+    custom_equation,
+    get_circuit_equation_number,
+    get_circuit_node_value,
+    solve,
+)
 
 import test_common
+
 # basic linear circuit solved by itself
 add_circuit_node(name="n1", variable_update="default")
 add_circuit_node(name="n2", variable_update="default")
@@ -16,16 +25,16 @@ circuit_element(name="V1", n1="n1", n2="0", value=1.0)
 def myassemble(what, timemode):
     n1 = get_circuit_equation_number(node="n1")
     n2 = get_circuit_equation_number(node="n2")
-    G1=1.0
-    G2=1.0
+    G1 = 1.0
+    G2 = 1.0
 
-    rcv=[]
-    rv=[]
+    rcv = []
+    rv = []
 
     if timemode != "DC":
         return [rcv, rv]
 
-    if  what != "MATRIXONLY":
+    if what != "MATRIXONLY":
         v1 = get_circuit_node_value(node="n1", solution="dcop")
         v2 = get_circuit_node_value(node="n2", solution="dcop")
 
@@ -35,7 +44,7 @@ def myassemble(what, timemode):
         rv.extend([n2, I2])
         rv.extend([n2, -I1])
 
-    if what !="RHS" :
+    if what != "RHS":
         mG1 = -G1
         mG2 = -G2
 
@@ -49,6 +58,7 @@ def myassemble(what, timemode):
     print(rv)
     return rcv, rv, False
 
+
 custom_equation(name="test1", procedure=myassemble)
 solve(type="dc", absolute_error=1.0, relative_error=1e-14, maximum_iterations=3)
 test_common.print_circuit_solution()
@@ -56,5 +66,3 @@ test_common.print_circuit_solution()
 circuit_alter(name="V1", value=2.0)
 solve(type="dc", absolute_error=1.0, relative_error=1e-14, maximum_iterations=3)
 test_common.print_circuit_solution()
-
-

--- a/testing/erf1.py
+++ b/testing/erf1.py
@@ -4,13 +4,14 @@
 
 import devsim
 import test_common
-device="MyDevice"
-region="MyRegion"
+
+device = "MyDevice"
+region = "MyRegion"
 
 # basic linear circuit solved by itself
-devsim.circuit_element(name="V1", n1=1,        n2=0,        value=1.0)
-devsim.circuit_element(name="R1", n1=1,        n2="cnode1", value=5.0)
-devsim.circuit_element(name="R2", n1="cnode1", n2=0,        value=5.0)
+devsim.circuit_element(name="V1", n1=1, n2=0, value=1.0)
+devsim.circuit_element(name="R1", n1=1, n2="cnode1", value=5.0)
+devsim.circuit_element(name="R2", n1="cnode1", n2=0, value=5.0)
 
 devsim.solve(type="dc", absolute_error=1.0, relative_error=1e-14, maximum_iterations=3)
 test_common.print_circuit_solution()
@@ -23,14 +24,20 @@ test_common.CreateSimpleMesh(device, region)
 
 devsim.node_model(device=device, region=region, name="erf", equation="erf(x);")
 devsim.print_node_values(device=device, region=region, name="erf")
-devsim.node_model(device=device, region=region, name="d_erf_dx", equation="diff(erf(x),x);")
+devsim.node_model(
+    device=device, region=region, name="d_erf_dx", equation="diff(erf(x),x);"
+)
 devsim.print_node_values(device=device, region=region, name="d_erf_dx")
 devsim.node_model(device=device, region=region, name="erfc", equation="erfc(x);")
 devsim.print_node_values(device=device, region=region, name="erfc")
-devsim.node_model(device=device, region=region, name="d_erfc_dx", equation="diff(erfc(x),x);")
+devsim.node_model(
+    device=device, region=region, name="d_erfc_dx", equation="diff(erfc(x),x);"
+)
 devsim.print_node_values(device=device, region=region, name="d_erfc_dx")
 
-devsim.node_model(device=device, region=region, name="d_abs_dx", equation="diff(abs(x),x);")
+devsim.node_model(
+    device=device, region=region, name="d_abs_dx", equation="diff(abs(x),x);"
+)
 devsim.print_node_values(device=device, region=region, name="d_abs_dx")
 
 devsim.set_parameter(name="param", value=-1.0)
@@ -43,4 +50,3 @@ devsim.node_model(device=device, region=region, name="cdeptest", equation="cnode
 devsim.print_node_values(device=device, region=region, name="cdeptest")
 devsim.set_circuit_node_value(node="cnode1", value=-1.0)
 devsim.print_node_values(device=device, region=region, name="cdeptest")
-

--- a/testing/erf2.py
+++ b/testing/erf2.py
@@ -4,8 +4,9 @@
 
 import devsim
 import test_common
-device="MyDevice"
-region="MyRegion"
+
+device = "MyDevice"
+region = "MyRegion"
 
 test_common.CreateSimpleMesh(device, region)
 # the mesh range is 0 to 1
@@ -16,21 +17,18 @@ myexp2 = "1.999*x+0.0001"
 
 
 for i, j in (
-      ("erf_inv", "erf_inv(x)"),
-      ("d_erf_inv_dx", "diff(erf_inv(x),x)"),
-      ("erfc_inv", "erfc_inv(x)"),
-      ("d_erfc_inv_dx", "diff(erfc_inv(x),x)"),
-      ("erf_inv", "erf_inv(%s)" % myexp1),
-      ("d_erf_inv_dx", "diff(erf_inv(%s),x)" % myexp1),
-      ("erfc_inv", "erfc_inv(%s)" % myexp2),
-      ("d_erfc_inv_dx", "diff(erfc_inv(%s),x)" % myexp2),
-    ):
+    ("erf_inv", "erf_inv(x)"),
+    ("d_erf_inv_dx", "diff(erf_inv(x),x)"),
+    ("erfc_inv", "erfc_inv(x)"),
+    ("d_erfc_inv_dx", "diff(erfc_inv(x),x)"),
+    ("erf_inv", "erf_inv(%s)" % myexp1),
+    ("d_erf_inv_dx", "diff(erf_inv(%s),x)" % myexp1),
+    ("erfc_inv", "erfc_inv(%s)" % myexp2),
+    ("d_erfc_inv_dx", "diff(erfc_inv(%s),x)" % myexp2),
+):
     devsim.node_model(device=device, region=region, name=i, equation=j)
     print()
     try:
         devsim.print_node_values(device=device, region=region, name=i)
-    except:
-        pass
-
-
-
+    except Exception as e:
+        print(f"Failed to print node values for {i}: {e}")

--- a/testing/fpetest1.py
+++ b/testing/fpetest1.py
@@ -5,18 +5,17 @@
 import devsim
 import test_common
 
-device="MyDevice"
-region="MyRegion"
+device = "MyDevice"
+region = "MyRegion"
 
 test_common.CreateSimpleMesh(device, region)
 
 for name, equation in (
     ("test1", "log(-1)"),
-  ("test2", "log(x)"),
+    ("test2", "log(x)"),
 ):
     devsim.node_model(device=device, region=region, name=name, equation=equation)
     try:
         print(devsim.get_node_model_values(device=device, region=region, name=name))
     except devsim.error as x:
         print(x)
-

--- a/testing/fpetest2.py
+++ b/testing/fpetest2.py
@@ -2,18 +2,22 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 import devsim
-devsim.set_parameter(name="threads_available", value=2)
 import fpetest1
+
+devsim.set_parameter(name="threads_available", value=2)
 
 for name, value in (
     ("threads_available", 1),
-  ("threads_available", 0),
-  ("threads_available", -1),
-  ("threads_available", 2),
+    ("threads_available", 0),
+    ("threads_available", -1),
+    ("threads_available", 2),
 ):
     devsim.set_parameter(name=name, value=value)
     try:
-        print(devsim.get_node_model_values(device=fpetest1.device, region=fpetest1.region, name="test2"))
+        print(
+            devsim.get_node_model_values(
+                device=fpetest1.device, region=fpetest1.region, name="test2"
+            )
+        )
     except devsim.error as x:
         print(x)
-

--- a/testing/info.py
+++ b/testing/info.py
@@ -7,5 +7,5 @@
 #### print features for this build
 ####
 import devsim
-print(devsim.get_parameter(name="info"))
 
+print(devsim.get_parameter(name="info"))

--- a/testing/kahan.py
+++ b/testing/kahan.py
@@ -5,16 +5,16 @@
 import devsim
 import test_common
 
-device="MyDevice"
-region="MyRegion"
+device = "MyDevice"
+region = "MyRegion"
 
 test_common.CreateSimpleMesh(device, region)
 
 for name, equation in (
     ("NetDoping1", "kahan3(1e20, -1e20, x);"),
-  ("NetDoping2", "kahan4(1e20, -1e20, x,1e14);"),
-  ("NetDoping3", "kahan3(x, 1e20, -1e20);"),
-  ("NetDoping4", "kahan4(x, 1e20, -1e20, 1e14);"),
+    ("NetDoping2", "kahan4(1e20, -1e20, x,1e14);"),
+    ("NetDoping3", "kahan3(x, 1e20, -1e20);"),
+    ("NetDoping4", "kahan4(x, 1e20, -1e20, 1e14);"),
 ):
     devsim.node_model(device=device, region=region, name=name, equation=equation)
     print(devsim.get_node_model_values(device=device, region=region, name=name))
@@ -22,4 +22,3 @@ for name, equation in (
 print(devsim.symdiff(expr="diff(kahan3(a,b,c),c);"))
 print(devsim.symdiff(expr="diff(kahan4(a,b,c,d),c);"))
 print(devsim.symdiff(expr="diff(kahan4(a,b,c,c),c);"))
-

--- a/testing/kahan_float128.py
+++ b/testing/kahan_float128.py
@@ -2,17 +2,17 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-#Purpose: Fermi integral and inverse
+# Purpose: Fermi integral and inverse
 
 import devsim
 import sys
 
-if not devsim.get_parameter(name='info')['extended_precision']:
+if not devsim.get_parameter(name="info")["extended_precision"]:
     print("Extended precision support is not available with this version")
     sys.exit(0)
 
-devsim.set_parameter(name = "extended_solver", value=True)
-devsim.set_parameter(name = "extended_model", value=True)
-devsim.set_parameter(name = "extended_equation", value=True)
+devsim.set_parameter(name="extended_solver", value=True)
+devsim.set_parameter(name="extended_model", value=True)
+devsim.set_parameter(name="extended_equation", value=True)
 
-import kahan
+import kahan  # noqa: E402, F401

--- a/testing/laux1.py
+++ b/testing/laux1.py
@@ -4,7 +4,7 @@
 
 # The purpose is to verify our triangle element field calculation.
 # It is based on Laux's weighting scheme
-#@article{Laux:1985,
+# @article{Laux:1985,
 # author = {Laux, Steven E. and Byrnes, Robert G.},
 # title = {Semiconductor device simulation using generalized mobility models},
 # journal = {IBM J. Res. Dev.},
@@ -21,41 +21,52 @@
 # acmid = {1012099},
 # publisher = {IBM Corp.},
 # address = {Riverton, NJ, USA},
-#}
+# }
 
 import sys
+
 try:
     import numpy
     import numpy.linalg
-except:
-    print("numpy is not available with your installation and is not being run")
+except ImportError:
+    print(
+        "numpy is not available with your installation and is required for this program to run."
+    )
     sys.exit(-1)
 
 
-from devsim import edge_from_node_model, element_from_edge_model, element_from_node_model, element_model, get_edge_model_values, get_element_model_values, load_devices
+from devsim import (
+    edge_from_node_model,
+    element_from_edge_model,
+    element_from_node_model,
+    element_model,
+    get_edge_model_values,
+    get_element_model_values,
+    load_devices,
+)
 
 
 def calculateValues(scalar_efield, eecouple, sx, sy):
-    '''
+    """
     calculates values, using the exact algorithm used internally to the software
-    '''
-    row0 = numpy.array([0, 0, 1])
-    row1 = numpy.array([1, 2, 2])
-    ans = numpy.zeros((3,1))
-    M = numpy.zeros((2,2))
-    B = numpy.zeros((2,1))
+    """
+    _row0 = numpy.array([0, 0, 1])
+    _row1 = numpy.array([1, 2, 2])
+    ans = numpy.zeros((3, 1))
+    M = numpy.zeros((2, 2))
+    B = numpy.zeros((2, 1))
     e_this = [0] * 2
-    e_opp  = [0] * 2
-    efx = [0] *len(scalar_efield)
-    efy = [0] *len(scalar_efield)
-    for ei in range(len(scalar_efield)//3):
+    e_opp = [0] * 2
+    efx = [0] * len(scalar_efield)
+    efy = [0] * len(scalar_efield)
+    for ei in range(len(scalar_efield) // 3):
         for i in range(3):
-            e_base = 3*ei + i
+            e_base = 3 * ei + i
             k = 0
             for j in range(3):
                 if i == j:
                     continue
-                e_this[k] = 3*ei + j
+                e_this[k] = 3 * ei + j
                 k = k + 1
 
             e_opp[0] = e_this[1]
@@ -73,11 +84,11 @@ def calculateValues(scalar_efield, eecouple, sx, sy):
                 M[1][1] = sy[e_this[j]]
                 B[1] = scalar_efield[e_this[j]]
                 ans = numpy.linalg.solve(M, B)
-                ex = ex + ans[0]*eecouple[e_this[j]]
-                ey = ey + ans[1]*eecouple[e_this[j]]
+                ex = ex + ans[0] * eecouple[e_this[j]]
+                ey = ey + ans[1] * eecouple[e_this[j]]
                 den = den + eecouple[e_this[j]]
-            efx[e_base] = ex/den
-            efy[e_base] = ey/den
+            efx[e_base] = ex / den
+            efy[e_base] = ey / den
     return (efx, efy)
 
 
@@ -86,24 +97,29 @@ device = "MyDevice"
 region = "MyRegion"
 # trying to verify Laux current waiting implementation
 # these are the scalar values
-element_model(device=device, region=region, name="scalar_efield", equation="ElectricField")
+element_model(
+    device=device, region=region, name="scalar_efield", equation="ElectricField"
+)
 element_model(device=device, region=region, name="sx", equation="unitx")
 element_model(device=device, region=region, name="sy", equation="unity")
 
-scalar_efield = get_element_model_values(device=device, region=region, name="scalar_efield")
+scalar_efield = get_element_model_values(
+    device=device, region=region, name="scalar_efield"
+)
 sx = get_element_model_values(device=device, region=region, name="sx")
 sy = get_element_model_values(device=device, region=region, name="sy")
 
 element_from_edge_model(device=device, region=region, edge_model="ElectricField")
 efieldx = get_element_model_values(device=device, region=region, name="ElectricField_x")
 efieldy = get_element_model_values(device=device, region=region, name="ElectricField_y")
-eecouple = get_element_model_values(device=device, region=region, name="ElementEdgeCouple")
-
+eecouple = get_element_model_values(
+    device=device, region=region, name="ElementEdgeCouple"
+)
 
 
 (ex, ey) = calculateValues(scalar_efield, eecouple, sx, sy)
 for i in range(len(ex)):
-    print("%g\t%g\t%g\t%g" %( ex[i][0], ey[i][0], efieldx[i], efieldy[i]))
+    print("%g\t%g\t%g\t%g" % (ex[i][0], ey[i][0], efieldx[i], efieldy[i]))
 
 #
 # now verify derivatives
@@ -111,66 +127,80 @@ for i in range(len(ex)):
 edge_from_node_model(node_model="node_index", device=device, region=region)
 edge_nodes = []
 potential_diff = []
-nedge=0
+nedge = 0
 for i in range(2):
-    tmp  = get_edge_model_values(device=device, region=region, name="node_index@n%d" % i)
+    tmp = get_edge_model_values(device=device, region=region, name="node_index@n%d" % i)
     if not edge_nodes:
-        nedge =len(tmp)
-        edge_nodes = [0]*nedge
-        potential_diff = [0]*nedge
+        nedge = len(tmp)
+        edge_nodes = [0] * nedge
+        potential_diff = [0] * nedge
         for j in range(nedge):
-            edge_nodes[j] = [0]*2
-            potential_diff[j] = [0]*2
+            edge_nodes[j] = [0] * 2
+            potential_diff[j] = [0] * 2
     for j in range(nedge):
         edge_nodes[j][i] = tmp[j]
-    tmp  = get_edge_model_values(device=device, region=region, name="ElectricField:Potential@n%d" % i)
+    tmp = get_edge_model_values(
+        device=device, region=region, name="ElectricField:Potential@n%d" % i
+    )
     for j in range(nedge):
         potential_diff[j][i] = tmp[j]
 
 
-
-
-element_model(device=device, region=region, name="scalar_edge_index", equation="edge_index")
-scalar_edge_index = get_element_model_values(device=device, region=region, name="scalar_edge_index")
+element_model(
+    device=device, region=region, name="scalar_edge_index", equation="edge_index"
+)
+scalar_edge_index = get_element_model_values(
+    device=device, region=region, name="scalar_edge_index"
+)
 scalar_edge_index = [int(x) for x in scalar_edge_index]
 element_from_node_model(node_model="node_index", device=device, region=region)
 
 nelem = len(efieldx)
-element_node_indexes = [0]*nelem
-ddata_x = [0]*nelem
-ddata_y = [0]*nelem
-cdata_x = [0]*nelem
-cdata_y = [0]*nelem
+element_node_indexes = [0] * nelem
+ddata_x = [0] * nelem
+ddata_y = [0] * nelem
+cdata_x = [0] * nelem
+cdata_y = [0] * nelem
 for i in range(nelem):
-    element_node_indexes[i] = [0]*3
-    ddata_x[i] = [0]*3
-    ddata_y[i] = [0]*3
-    cdata_x[i] = [0]*3
-    cdata_y[i] = [0]*3
+    element_node_indexes[i] = [0] * 3
+    ddata_x[i] = [0] * 3
+    ddata_y[i] = [0] * 3
+    cdata_x[i] = [0] * 3
+    cdata_y[i] = [0] * 3
 for i in range(3):
-    tmp  = get_element_model_values(device=device, region=region, name="node_index@en%d" % i)
+    tmp = get_element_model_values(
+        device=device, region=region, name="node_index@en%d" % i
+    )
     for j in range(nelem):
         element_node_indexes[j][i] = int(tmp[j])
 
-element_from_edge_model(device=device, region=region, edge_model="ElectricField", derivative="Potential")
+element_from_edge_model(
+    device=device, region=region, edge_model="ElectricField", derivative="Potential"
+)
 for i in range(3):
-    tmp  = get_element_model_values(device=device, region=region, name="ElectricField_x:Potential@en%d" % i)
+    tmp = get_element_model_values(
+        device=device, region=region, name="ElectricField_x:Potential@en%d" % i
+    )
     for j in range(nelem):
         cdata_x[j][i] = tmp[j]
 for i in range(3):
-    tmp  = get_element_model_values(device=device, region=region, name="ElectricField_y:Potential@en%d" % i)
+    tmp = get_element_model_values(
+        device=device, region=region, name="ElectricField_y:Potential@en%d" % i
+    )
     for j in range(nelem):
         cdata_y[j][i] = tmp[j]
 
-diff_field = [0]*nelem
-dest_map = [0]*nelem # maps global node of element to this particular edge
-for dnode in range(3): #this is the node we are taking the derivative with respect to
-                       # it is the global node index and will be figure out shortly
-    for i in range(nelem//3):
-        bi = 3*i  # this is the base element edge(0)
-        dindex = element_node_indexes[bi][dnode]# this is the node we are taking the derivative with respect to
-        for j in range(3): # this is the edge of interest
-            ei = bi + j # this is the edge we are looking at
+diff_field = [0] * nelem
+dest_map = [0] * nelem  # maps global node of element to this particular edge
+for dnode in range(3):  # this is the node we are taking the derivative with respect to
+    # it is the global node index and will be figure out shortly
+    for i in range(nelem // 3):
+        bi = 3 * i  # this is the base element edge(0)
+        dindex = element_node_indexes[bi][
+            dnode
+        ]  # this is the node we are taking the derivative with respect to
+        for j in range(3):  # this is the edge of interest
+            ei = bi + j  # this is the edge we are looking at
             sei = scalar_edge_index[ei]
             if dindex in edge_nodes[sei]:
                 pos = edge_nodes[sei].index(dindex)
@@ -183,17 +213,20 @@ for dnode in range(3): #this is the node we are taking the derivative with respe
         ddata_x[i][dest_map[i]] = ex[i]
         ddata_y[i][dest_map[i]] = ey[i]
         # these are the node indexes w.r.t. the first edge on the triangle
-        #ddata_x[i][dnode] = ex[i]
-        #ddata_y[i][dnode] = ey[i]
+        # ddata_x[i][dnode] = ex[i]
+        # ddata_y[i][dnode] = ey[i]
 
-#print element_node_indexes
+# print element_node_indexes
 
 for i in range(3):
     print("index %d" % i)
     for j in range(nelem):
-        print("%g\t%g\t%g\t%g" %( ddata_x[j][i][0], ddata_y[j][i][0], cdata_x[j][i], cdata_y[j][i]))
+        print(
+            "%g\t%g\t%g\t%g"
+            % (ddata_x[j][i][0], ddata_y[j][i][0], cdata_x[j][i], cdata_y[j][i])
+        )
 
-#print element_node_indexes
-#print potential_diff
-#print get_edge_model_values(device=device, region=region, name="ElectricField:Potential@n0")
-#print get_edge_model_values(device=device, region=region, name="ElectricField:Potential@n1")
+# print element_node_indexes
+# print potential_diff
+# print get_edge_model_values(device=device, region=region, name="ElectricField:Potential@n0")
+# print get_edge_model_values(device=device, region=region, name="ElectricField:Potential@n1")

--- a/testing/mesh1.py
+++ b/testing/mesh1.py
@@ -4,55 +4,118 @@
 
 import devsim
 
-devsim.load_devices( file="mesh1.msh")
+devsim.load_devices(file="mesh1.msh")
 
 for x in devsim.get_device_list():
     for y in devsim.get_region_list(device=x):
         print("%s %s" % (x, y))
 
-device="MyDevice"
-region="MyRegion"
+device = "MyDevice"
+region = "MyRegion"
 
-devsim.set_parameter( device=device, region=region, name="Permittivity", value=3.9*8.85e-14)
-devsim.set_parameter( device=device, region=region, name="ElectricCharge", value=1.6e-19)
+devsim.set_parameter(
+    device=device, region=region, name="Permittivity", value=3.9 * 8.85e-14
+)
+devsim.set_parameter(device=device, region=region, name="ElectricCharge", value=1.6e-19)
 
 
-devsim.node_solution( device=device, region=region, name="Potential")
+devsim.node_solution(device=device, region=region, name="Potential")
 
 devsim.edge_from_node_model(device=device, region=region, node_model="Potential")
 
-devsim.edge_model( device=device, region=region, name="ElectricField",              equation="(Potential@n0 - Potential@n1)*EdgeInverseLength")
-devsim.edge_model( device=device, region=region, name="ElectricField:Potential@n0", equation="EdgeInverseLength")
-devsim.edge_model( device=device, region=region, name="ElectricField:Potential@n1", equation="-EdgeInverseLength")
+devsim.edge_model(
+    device=device,
+    region=region,
+    name="ElectricField",
+    equation="(Potential@n0 - Potential@n1)*EdgeInverseLength",
+)
+devsim.edge_model(
+    device=device,
+    region=region,
+    name="ElectricField:Potential@n0",
+    equation="EdgeInverseLength",
+)
+devsim.edge_model(
+    device=device,
+    region=region,
+    name="ElectricField:Potential@n1",
+    equation="-EdgeInverseLength",
+)
 
-devsim.set_parameter( device=device, region=region, name="topbias",    value=1.0e-0)
-devsim.set_parameter( device=device, region=region, name="botbias", value=0.0)
+devsim.set_parameter(device=device, region=region, name="topbias", value=1.0e-0)
+devsim.set_parameter(device=device, region=region, name="botbias", value=0.0)
 
-devsim.edge_model( device=device, region=region, name="PotentialEdgeFlux", equation="Permittivity*ElectricField")
-devsim.edge_model( device=device, region=region, name="PotentialEdgeFlux:Potential@n0", equation="diff(Permittivity*ElectricField, Potential@n0)")
-devsim.edge_model( device=device, region=region, name="PotentialEdgeFlux:Potential@n1", equation="-PotentialEdgeFlux:Potential@n0")
+devsim.edge_model(
+    device=device,
+    region=region,
+    name="PotentialEdgeFlux",
+    equation="Permittivity*ElectricField",
+)
+devsim.edge_model(
+    device=device,
+    region=region,
+    name="PotentialEdgeFlux:Potential@n0",
+    equation="diff(Permittivity*ElectricField, Potential@n0)",
+)
+devsim.edge_model(
+    device=device,
+    region=region,
+    name="PotentialEdgeFlux:Potential@n1",
+    equation="-PotentialEdgeFlux:Potential@n0",
+)
 
-devsim.equation( device=device, region=region, name="PotentialEquation", variable_name="Potential", edge_model="PotentialEdgeFlux", variable_update="default")
+devsim.equation(
+    device=device,
+    region=region,
+    name="PotentialEquation",
+    variable_name="Potential",
+    edge_model="PotentialEdgeFlux",
+    variable_update="default",
+)
 
-devsim.node_model( device=device, region=region, name="topnode_model"          , equation="Potential - topbias")
-devsim.node_model( device=device, region=region, name="topnode_model:Potential", equation="1")
+devsim.node_model(
+    device=device, region=region, name="topnode_model", equation="Potential - topbias"
+)
+devsim.node_model(
+    device=device, region=region, name="topnode_model:Potential", equation="1"
+)
 
-devsim.node_model( device=device, region=region, name="botnode_model"          , equation="Potential - botbias")
-devsim.node_model( device=device, region=region, name="botnode_model:Potential", equation="1")
+devsim.node_model(
+    device=device, region=region, name="botnode_model", equation="Potential - botbias"
+)
+devsim.node_model(
+    device=device, region=region, name="botnode_model:Potential", equation="1"
+)
 
-devsim.contact_equation( device=device, contact="top", name="PotentialEquation", node_model="topnode_model",
-                         edge_charge_model="PotentialEdgeFlux")
+devsim.contact_equation(
+    device=device,
+    contact="top",
+    name="PotentialEquation",
+    node_model="topnode_model",
+    edge_charge_model="PotentialEdgeFlux",
+)
 
-devsim.contact_equation( device=device, contact="bot", name="PotentialEquation", node_model="botnode_model",
-                         edge_charge_model="PotentialEdgeFlux")
+devsim.contact_equation(
+    device=device,
+    contact="bot",
+    name="PotentialEquation",
+    node_model="botnode_model",
+    edge_charge_model="PotentialEdgeFlux",
+)
 
 devsim.solve(type="dc", absolute_error=1.0, relative_error=1e-10, maximum_iterations=30)
 
-print(devsim.get_contact_charge(device=device, contact="top", equation="PotentialEquation"))
-print(devsim.get_contact_charge(device=device, contact="bot", equation="PotentialEquation"))
+print(
+    devsim.get_contact_charge(
+        device=device, contact="top", equation="PotentialEquation"
+    )
+)
+print(
+    devsim.get_contact_charge(
+        device=device, contact="bot", equation="PotentialEquation"
+    )
+)
 
 devsim.print_node_values(device=device, region=region, name="NodeVolume")
 devsim.print_edge_values(device=device, region=region, name="ElectricField")
 devsim.print_edge_values(device=device, region=region, name="EdgeCouple")
-
-

--- a/testing/mesh2.py
+++ b/testing/mesh2.py
@@ -4,73 +4,187 @@
 
 import devsim
 
-devsim.load_devices( file="mesh2.msh")
+devsim.load_devices(file="mesh2.msh")
 
 for x in devsim.get_device_list():
     for y in devsim.get_region_list(device=x):
         print("%s %s" % (x, y))
 
-device="MyDevice"
-interface="MySiOx"
-regions=("MyOxRegion", "MySiRegion")
+device = "MyDevice"
+interface = "MySiOx"
+regions = ("MyOxRegion", "MySiRegion")
 
-devsim.set_parameter( device=device, region="MySiRegion", name="Permittivity", value=11.1*8.85e-14)
-devsim.set_parameter( device=device, region="MySiRegion", name="ElectricCharge", value=1.6e-19)
+devsim.set_parameter(
+    device=device, region="MySiRegion", name="Permittivity", value=11.1 * 8.85e-14
+)
+devsim.set_parameter(
+    device=device, region="MySiRegion", name="ElectricCharge", value=1.6e-19
+)
 
-devsim.set_parameter( device=device, region="MyOxRegion", name="Permittivity", value=3.9*8.85e-14)
-devsim.set_parameter( device=device, region="MyOxRegion", name="ElectricCharge", value=1.6e-19)
+devsim.set_parameter(
+    device=device, region="MyOxRegion", name="Permittivity", value=3.9 * 8.85e-14
+)
+devsim.set_parameter(
+    device=device, region="MyOxRegion", name="ElectricCharge", value=1.6e-19
+)
 
 for region in regions:
-    devsim.node_solution( device=device, region=region, name="Potential")
-    devsim.edge_from_node_model( device=device, region=region, node_model="Potential")
+    devsim.node_solution(device=device, region=region, name="Potential")
+    devsim.edge_from_node_model(device=device, region=region, node_model="Potential")
 
-    devsim.edge_model( device=device, region=region, name="ElectricField", equation="(Potential@n0 - Potential@n1)*EdgeInverseLength")
-    devsim.edge_model( device=device, region=region, name="ElectricField:Potential@n0", equation="EdgeInverseLength")
-    devsim.edge_model( device=device, region=region, name="ElectricField:Potential@n1", equation="-EdgeInverseLength")
+    devsim.edge_model(
+        device=device,
+        region=region,
+        name="ElectricField",
+        equation="(Potential@n0 - Potential@n1)*EdgeInverseLength",
+    )
+    devsim.edge_model(
+        device=device,
+        region=region,
+        name="ElectricField:Potential@n0",
+        equation="EdgeInverseLength",
+    )
+    devsim.edge_model(
+        device=device,
+        region=region,
+        name="ElectricField:Potential@n1",
+        equation="-EdgeInverseLength",
+    )
 
-    devsim.edge_model( device=device, region=region, name="PotentialEdgeFlux", equation="Permittivity*ElectricField")
-    devsim.edge_model( device=device, region=region, name="PotentialEdgeFlux:Potential@n0", equation="diff(Permittivity*ElectricField, Potential@n0)")
-    devsim.edge_model( device=device, region=region, name="PotentialEdgeFlux:Potential@n1", equation="-PotentialEdgeFlux:Potential@n0")
+    devsim.edge_model(
+        device=device,
+        region=region,
+        name="PotentialEdgeFlux",
+        equation="Permittivity*ElectricField",
+    )
+    devsim.edge_model(
+        device=device,
+        region=region,
+        name="PotentialEdgeFlux:Potential@n0",
+        equation="diff(Permittivity*ElectricField, Potential@n0)",
+    )
+    devsim.edge_model(
+        device=device,
+        region=region,
+        name="PotentialEdgeFlux:Potential@n1",
+        equation="-PotentialEdgeFlux:Potential@n0",
+    )
 
-    devsim.equation( device=device, region=region, name="PotentialEquation", variable_name="Potential", edge_model="PotentialEdgeFlux", variable_update="default")
+    devsim.equation(
+        device=device,
+        region=region,
+        name="PotentialEquation",
+        variable_name="Potential",
+        edge_model="PotentialEdgeFlux",
+        variable_update="default",
+    )
 
-devsim.set_parameter( device=device, name="topbias",    value=1.0)
-devsim.set_parameter( device=device, name="botbias", value=0.0)
+devsim.set_parameter(device=device, name="topbias", value=1.0)
+devsim.set_parameter(device=device, name="botbias", value=0.0)
 
 
+devsim.node_model(
+    device=device,
+    region="MySiRegion",
+    name="topnode_model",
+    equation="Potential - topbias",
+)
+devsim.node_model(
+    device=device, region="MySiRegion", name="topnode_model:Potential", equation="1"
+)
 
-devsim.node_model( device=device, region="MySiRegion", name="topnode_model"          , equation="Potential - topbias")
-devsim.node_model( device=device, region="MySiRegion", name="topnode_model:Potential", equation="1")
+devsim.node_model(
+    device=device,
+    region="MyOxRegion",
+    name="botnode_model",
+    equation="Potential - botbias",
+)
+devsim.node_model(
+    device=device, region="MyOxRegion", name="botnode_model:Potential", equation="1"
+)
 
-devsim.node_model( device=device, region="MyOxRegion", name="botnode_model"          , equation="Potential - botbias")
-devsim.node_model( device=device, region="MyOxRegion", name="botnode_model:Potential", equation="1")
+devsim.contact_equation(
+    device=device,
+    contact="top",
+    name="PotentialEquation",
+    node_model="topnode_model",
+    edge_charge_model="PotentialEdgeFlux",
+)
 
-devsim.contact_equation( device=device, contact="top", name="PotentialEquation",
-                         node_model="topnode_model", edge_charge_model="PotentialEdgeFlux")
+devsim.contact_equation(
+    device=device,
+    contact="top",
+    name="PotentialEquation",
+    node_model="topnode_model",
+    edge_charge_model="PotentialEdgeFlux",
+)
 
-devsim.contact_equation( device=device, contact="top", name="PotentialEquation",
-                         node_model="topnode_model", edge_charge_model="PotentialEdgeFlux")
-
-devsim.contact_equation( device=device, contact="bot", name="PotentialEquation",
-                         node_model="botnode_model", edge_charge_model="PotentialEdgeFlux")
+devsim.contact_equation(
+    device=device,
+    contact="bot",
+    name="PotentialEquation",
+    node_model="botnode_model",
+    edge_charge_model="PotentialEdgeFlux",
+)
 
 # type continuous means that regular equations in both regions are swapped into the primary region
-devsim.interface_model( device=device, interface=interface, name="continuousPotential", equation="Potential@r0-Potential@r1")
-devsim.interface_model( device=device, interface=interface, name="continuousPotential:Potential@r0", equation= "1")
-devsim.interface_model( device=device, interface=interface, name="continuousPotential:Potential@r1", equation="-1")
-devsim.interface_equation( device=device, interface=interface, name="PotentialEquation", interface_model="continuousPotential", type="continuous")
-
+devsim.interface_model(
+    device=device,
+    interface=interface,
+    name="continuousPotential",
+    equation="Potential@r0-Potential@r1",
+)
+devsim.interface_model(
+    device=device,
+    interface=interface,
+    name="continuousPotential:Potential@r0",
+    equation="1",
+)
+devsim.interface_model(
+    device=device,
+    interface=interface,
+    name="continuousPotential:Potential@r1",
+    equation="-1",
+)
+devsim.interface_equation(
+    device=device,
+    interface=interface,
+    name="PotentialEquation",
+    interface_model="continuousPotential",
+    type="continuous",
+)
 
 
 def print_charge():
-    print(devsim.get_contact_charge( device=device, contact="top", equation="PotentialEquation"))
-    print(devsim.get_contact_charge( device=device, contact="bot", equation="PotentialEquation"))
+    print(
+        devsim.get_contact_charge(
+            device=device, contact="top", equation="PotentialEquation"
+        )
+    )
+    print(
+        devsim.get_contact_charge(
+            device=device, contact="bot", equation="PotentialEquation"
+        )
+    )
+
+
 def print_flux():
-    devsim.print_edge_values(device=device, region="MySiRegion", name="PotentialEdgeFlux")
-    devsim.print_edge_values(device=device, region="MyOxRegion", name="PotentialEdgeFlux")
+    devsim.print_edge_values(
+        device=device, region="MySiRegion", name="PotentialEdgeFlux"
+    )
+    devsim.print_edge_values(
+        device=device, region="MyOxRegion", name="PotentialEdgeFlux"
+    )
+
+
 def set_permittivities(ox, si):
-    devsim.set_parameter( device=device, region="MySiRegion", name="Permittivity", value=si*8.85e-14)
-    devsim.set_parameter( device=device, region="MyOxRegion", name="Permittivity", value=ox*8.85e-14)
+    devsim.set_parameter(
+        device=device, region="MySiRegion", name="Permittivity", value=si * 8.85e-14
+    )
+    devsim.set_parameter(
+        device=device, region="MyOxRegion", name="Permittivity", value=ox * 8.85e-14
+    )
+
 
 devsim.solve(type="dc", absolute_error=1.0, relative_error=1e-10, maximum_iterations=30)
 print_charge()
@@ -82,7 +196,7 @@ print_charge()
 print_flux()
 
 # makes sure this global scope does not interfere
-devsim.set_parameter( device=device, name="Permittivity", value=11.1*8.85e-14)
+devsim.set_parameter(device=device, name="Permittivity", value=11.1 * 8.85e-14)
 
 set_permittivities(si=11.1, ox=3.9)
 devsim.solve(type="dc", absolute_error=1.0, relative_error=1e-10, maximum_iterations=30)
@@ -94,4 +208,3 @@ devsim.print_edge_values(device=device, region="MyOxRegion", name="ElectricField
 
 devsim.print_node_values(device=device, region="MySiRegion", name="Potential")
 devsim.print_node_values(device=device, region="MyOxRegion", name="Potential")
-

--- a/testing/mesh2d.py
+++ b/testing/mesh2d.py
@@ -4,24 +4,24 @@
 
 import devsim
 
-device="MyDevice"
-region="MyRegion"
+device = "MyDevice"
+region = "MyRegion"
 
-xmin=0.0
-xmax=1.0
-ymin=0.0
+xmin = 0.0
+xmax = 1.0
+ymin = 0.0
 ### not that ymid my not exactly line up with a 0.5 gathered through summation, so use closes bloat with triangle rule to claim ownership
-ymid1=0.5
-ymid2=0.6
-ymax=1.0
+ymid1 = 0.5
+ymid2 = 0.6
+ymax = 1.0
 
-devsim.create_2d_mesh(   mesh="dog")
+devsim.create_2d_mesh(mesh="dog")
 devsim.add_2d_mesh_line(mesh="dog", dir="y", pos=-0.001, ps=0.001)
-devsim.add_2d_mesh_line(mesh="dog", dir="x", pos=xmin,   ps=0.1)
-devsim.add_2d_mesh_line(mesh="dog", dir="x", pos=xmax,   ps=0.1)
-devsim.add_2d_mesh_line(mesh="dog", dir="y", pos=ymin,   ps=0.1)
-devsim.add_2d_mesh_line(mesh="dog", dir="y", pos=ymax,   ps=0.1)
-#in order to capture interfaces
+devsim.add_2d_mesh_line(mesh="dog", dir="x", pos=xmin, ps=0.1)
+devsim.add_2d_mesh_line(mesh="dog", dir="x", pos=xmax, ps=0.1)
+devsim.add_2d_mesh_line(mesh="dog", dir="y", pos=ymin, ps=0.1)
+devsim.add_2d_mesh_line(mesh="dog", dir="y", pos=ymax, ps=0.1)
+# in order to capture interfaces
 devsim.add_2d_mesh_line(mesh="dog", dir="y", pos=+1.001, ps=0.001)
 # color triangles not nodes or edges
 # error if region doesn't have any triangles
@@ -29,26 +29,58 @@ devsim.add_2d_mesh_line(mesh="dog", dir="y", pos=+1.001, ps=0.001)
 # allow use of names or tags
 # check my parser to verify that adding is possible (via dynamic_cast)
 # note this region won't have equation numbers
-devsim.add_2d_region( mesh="dog", material="gas", region="gas1", yl=-.001, yh=0.0)
-devsim.add_2d_region( mesh="dog", material="gas", region="gas2", yl=1.0, yh=1.001)
-devsim.add_2d_region( mesh="dog", material="Oxide", region="r0", xl=xmin, xh=xmax, yl=ymid1, yh=ymin)
-devsim.add_2d_region( mesh="dog", material="Silicon", region="r1", xl=xmin, xh=xmax, yl=ymid2, yh=ymid1)
-devsim.add_2d_region( mesh="dog", material="Silicon", region="r2", xl=xmin, xh=xmax, yl=ymid2, yh=ymax)
-#warn when leftover triangles are not encapsulated by region
+devsim.add_2d_region(mesh="dog", material="gas", region="gas1", yl=-0.001, yh=0.0)
+devsim.add_2d_region(mesh="dog", material="gas", region="gas2", yl=1.0, yh=1.001)
+devsim.add_2d_region(
+    mesh="dog", material="Oxide", region="r0", xl=xmin, xh=xmax, yl=ymid1, yh=ymin
+)
+devsim.add_2d_region(
+    mesh="dog", material="Silicon", region="r1", xl=xmin, xh=xmax, yl=ymid2, yh=ymid1
+)
+devsim.add_2d_region(
+    mesh="dog", material="Silicon", region="r2", xl=xmin, xh=xmax, yl=ymid2, yh=ymax
+)
+# warn when leftover triangles are not encapsulated by region
 # not specifying bounding box means all intersecting nodes
-#bounding box is optional
-devsim.add_2d_interface( mesh="dog", name="i0", region0="r0", region1="r1")
-devsim.add_2d_interface( mesh="dog", name="i1", region0="r1", region1="r2", xl=0, xh=1, yl=ymid2, yh=ymid2, bloat=1.0e-10)
-devsim.add_2d_contact( mesh="dog", name="top", region="r0", yl=ymin, yh=ymin, bloat=1.0e-10, material="metal")
-devsim.add_2d_contact( mesh="dog", name="bot", region="r2", yl=ymax, yh=ymax, bloat=1.0e-10, material="metal")
-#contact can only apply interface
-devsim.finalize_mesh( mesh="dog")
+# bounding box is optional
+devsim.add_2d_interface(mesh="dog", name="i0", region0="r0", region1="r1")
+devsim.add_2d_interface(
+    mesh="dog",
+    name="i1",
+    region0="r1",
+    region1="r2",
+    xl=0,
+    xh=1,
+    yl=ymid2,
+    yh=ymid2,
+    bloat=1.0e-10,
+)
+devsim.add_2d_contact(
+    mesh="dog",
+    name="top",
+    region="r0",
+    yl=ymin,
+    yh=ymin,
+    bloat=1.0e-10,
+    material="metal",
+)
+devsim.add_2d_contact(
+    mesh="dog",
+    name="bot",
+    region="r2",
+    yl=ymax,
+    yh=ymax,
+    bloat=1.0e-10,
+    material="metal",
+)
+# contact can only apply interface
+devsim.finalize_mesh(mesh="dog")
 devsim.create_device(mesh="dog", device=device)
 
 devsim.node_model(device=device, name="NetDoping", region="gas1", equation="1e18")
-devsim.node_model(device=device, name="NetDoping", region="r0",   equation="1e18")
-devsim.node_model(device=device, name="NetDoping", region="r1",   equation="-1e15")
-devsim.node_model(device=device, name="NetDoping", region="r2",   equation="-1e15")
+devsim.node_model(device=device, name="NetDoping", region="r0", equation="1e18")
+devsim.node_model(device=device, name="NetDoping", region="r1", equation="-1e15")
+devsim.node_model(device=device, name="NetDoping", region="r2", equation="-1e15")
 devsim.node_model(device=device, name="NetDoping", region="gas2", equation="-1e15")
 
 devsim.interface_normal_model(device=device, region="r0", interface="i0")
@@ -60,11 +92,10 @@ devsim.set_parameter(name="raxis_zero", value=0.0)
 devsim.set_parameter(name="raxis_variable", value="x")
 
 for region in ("r0", "r1", "r2"):
-    devsim.cylindrical_node_volume(  device=device, region=region)
-    devsim.cylindrical_edge_couple(  device=device, region=region)
-    devsim.cylindrical_surface_area( device=device, region=region)
+    devsim.cylindrical_node_volume(device=device, region=region)
+    devsim.cylindrical_edge_couple(device=device, region=region)
+    devsim.cylindrical_surface_area(device=device, region=region)
 
 devsim.write_devices(file="mesh2d.flps", type="floops")
-devsim.write_devices(file="mesh2d.msh",  type="devsim")
-devsim.write_devices(file="mesh2d.dat",  type="tecplot")
-
+devsim.write_devices(file="mesh2d.msh", type="devsim")
+devsim.write_devices(file="mesh2d.dat", type="tecplot")

--- a/testing/mesh3.py
+++ b/testing/mesh3.py
@@ -3,6 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import devsim
+
 devsim.load_devices(file="mesh2.msh")
 devsim.write_devices(file="mesh3.msh", type="devsim_data", device="MyDevice")
-

--- a/testing/mesh4.py
+++ b/testing/mesh4.py
@@ -3,5 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import devsim
+
 devsim.load_devices(file="mesh3.msh")
 devsim.write_devices(file="mesh4.msh", type="devsim_data")

--- a/testing/mos_2d.py
+++ b/testing/mos_2d.py
@@ -2,15 +2,36 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from devsim.python_packages.simple_physics import GetContactBiasName, SetOxideParameters, SetSiliconParameters, CreateSiliconPotentialOnly, CreateSiliconPotentialOnlyContact, CreateSiliconDriftDiffusion, CreateSiliconDriftDiffusionAtContact, CreateOxidePotentialOnly, CreateSiliconOxideInterface
+from devsim.python_packages.simple_physics import (
+    GetContactBiasName,
+    SetOxideParameters,
+    SetSiliconParameters,
+    CreateSiliconPotentialOnly,
+    CreateSiliconPotentialOnlyContact,
+    CreateSiliconDriftDiffusion,
+    CreateSiliconDriftDiffusionAtContact,
+    CreateOxidePotentialOnly,
+    CreateSiliconOxideInterface,
+)
 from devsim.python_packages.model_create import CreateSolution
-from devsim import get_contact_list, get_device_list, get_parameter, get_parameter_list, get_region_list, node_model, set_node_values, set_parameter, solve, write_devices
+from devsim import (
+    get_contact_list,
+    get_device_list,
+    get_parameter,
+    get_parameter_list,
+    get_region_list,
+    node_model,
+    set_node_values,
+    set_parameter,
+    solve,
+    write_devices,
+)
 
-import mos_2d_create
+import mos_2d_create  # noqa: F401, E402
 
 device = "mymos"
-silicon_regions=("gate", "bulk")
-oxide_regions=("oxide",)
+silicon_regions = ("gate", "bulk")
+oxide_regions = ("oxide",)
 regions = ("gate", "bulk", "oxide")
 interfaces = ("bulk_oxide", "gate_oxide")
 
@@ -46,8 +67,10 @@ write_devices(file="gmsh_mos2d_potentialonly", type="vtk")
 for i in silicon_regions:
     CreateSolution(device, i, "Electrons")
     CreateSolution(device, i, "Holes")
-    set_node_values(device=device, region=i, name="Electrons", init_from="IntrinsicElectrons")
-    set_node_values(device=device, region=i, name="Holes",     init_from="IntrinsicHoles")
+    set_node_values(
+        device=device, region=i, name="Electrons", init_from="IntrinsicElectrons"
+    )
+    set_node_values(device=device, region=i, name="Holes", init_from="IntrinsicHoles")
     CreateSiliconDriftDiffusion(device, i, "mu_n", "mu_p")
 
 for c in contacts:
@@ -58,25 +81,31 @@ for c in contacts:
 solve(type="dc", absolute_error=1.0e30, relative_error=1e-5, maximum_iterations=30)
 
 for r in silicon_regions:
-    node_model(device=device, region=r, name="logElectrons", equation="log(Electrons)/log(10)")
+    node_model(
+        device=device, region=r, name="logElectrons", equation="log(Electrons)/log(10)"
+    )
 
 write_devices(file="mos_2d_dd.msh", type="devsim")
 
 with open("mos_2d_params.py", "w", encoding="utf-8") as ofh:
-    ofh.write('import devsim\n')
+    ofh.write("import devsim\n")
     for p in get_parameter_list():
-        if p in ('solver_callback', 'direct_solver', 'info'):
+        if p in ("solver_callback", "direct_solver", "info"):
             continue
-        v=repr(get_parameter(name=p))
+        v = repr(get_parameter(name=p))
         ofh.write('devsim.set_parameter(name="%s", value=%s)\n' % (p, v))
     for i in get_device_list():
         for p in get_parameter_list(device=i):
-            v=repr(get_parameter(device=i, name=p))
-            ofh.write('devsim.set_parameter(device="%s", name="%s", value=%s)\n' % (i, p, v))
+            v = repr(get_parameter(device=i, name=p))
+            ofh.write(
+                'devsim.set_parameter(device="%s", name="%s", value=%s)\n' % (i, p, v)
+            )
 
     for i in get_device_list():
         for j in get_region_list(device=i):
             for p in get_parameter_list(device=i, region=j):
-                v=repr(get_parameter(device=i, region=j, name=p))
-                ofh.write('devsim.set_parameter(device="%s", region="%s", name="%s", value=%s)\n' % (i, j, p, v))
-
+                v = repr(get_parameter(device=i, region=j, name=p))
+                ofh.write(
+                    'devsim.set_parameter(device="%s", region="%s", name="%s", value=%s)\n'
+                    % (i, j, p, v)
+                )

--- a/testing/mos_2d_create.py
+++ b/testing/mos_2d_create.py
@@ -3,69 +3,76 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import devsim
-device="mymos"
 
-device_width=   1.0e-4
-gate_width=     1.0e-5
-diffusion_width=0.4
+device = "mymos"
 
-air_thickness=      1e-7
-oxide_thickness=    1e-5
-gate_thickness=     1e-5
-device_thickness=   1e-4
-diffusion_thickness=1e-5
+device_width = 1.0e-4
+gate_width = 1.0e-5
+diffusion_width = 0.4
 
-x_diffusion_decay=  1e-20
-y_diffusion_decay=  1e-10
+air_thickness = 1e-7
+oxide_thickness = 1e-5
+gate_thickness = 1e-5
+device_thickness = 1e-4
+diffusion_thickness = 1e-5
 
-bulk_doping=        -1e15
-body_doping=        -1e19
-drain_doping=       1e19
-source_doping=      1e19
-gate_doping=        1e20
+x_diffusion_decay = 1e-20
+y_diffusion_decay = 1e-10
 
-y_channel_spacing=    1e-8
-y_diffusion_spacing=  1e-6
-y_gate_top_spacing=   1e-8
-y_gate_mid_spacing=   (gate_thickness * 0.25)
-y_gate_bot_spacing=   1e-8
-y_oxide_mid_spacing=  (oxide_thickness * 0.25)
-x_channel_spacing=  1e-6
-x_diffusion_spacing=1e-5
-max_y_spacing=      1e-4
-max_x_spacing=      1e-2
-y_bulk_mid_spacing=(device_thickness * 0.25)
-y_bulk_bottom_spacing=1e-8
+bulk_doping = -1e15
+body_doping = -1e19
+drain_doping = 1e19
+source_doping = 1e19
+gate_doping = 1e20
 
-x_bulk_left=  0.0
-x_bulk_right= (x_bulk_left + device_width)
-x_center=     (0.5 * (x_bulk_left + x_bulk_right))
-x_gate_left=  (x_center - 0.5 * (gate_width))
-x_gate_right= (x_center + 0.5 * (gate_width))
-x_device_left=(x_bulk_left - air_thickness)
-x_device_right=(x_bulk_right + air_thickness)
+y_channel_spacing = 1e-8
+y_diffusion_spacing = 1e-6
+y_gate_top_spacing = 1e-8
+y_gate_mid_spacing = gate_thickness * 0.25
+y_gate_bot_spacing = 1e-8
+y_oxide_mid_spacing = oxide_thickness * 0.25
+x_channel_spacing = 1e-6
+x_diffusion_spacing = 1e-5
+max_y_spacing = 1e-4
+max_x_spacing = 1e-2
+y_bulk_mid_spacing = device_thickness * 0.25
+y_bulk_bottom_spacing = 1e-8
 
-y_bulk_top=     0.0
-y_oxide_top=    (y_bulk_top - oxide_thickness)
-y_oxide_mid=    (0.5 * (y_oxide_top + y_bulk_top))
-y_gate_top=     (y_oxide_top - gate_thickness)
-y_gate_mid=     (0.5 * (y_gate_top + y_oxide_top))
-y_device_top=   (y_gate_top - air_thickness)
-y_bulk_bottom=  (y_bulk_top + device_thickness)
-y_bulk_mid=     (0.5 * (y_bulk_top + y_bulk_bottom))
-y_device_bottom=(y_bulk_bottom + air_thickness)
-y_diffusion=    (y_bulk_top + diffusion_thickness)
+x_bulk_left = 0.0
+x_bulk_right = x_bulk_left + device_width
+x_center = 0.5 * (x_bulk_left + x_bulk_right)
+x_gate_left = x_center - 0.5 * (gate_width)
+x_gate_right = x_center + 0.5 * (gate_width)
+x_device_left = x_bulk_left - air_thickness
+x_device_right = x_bulk_right + air_thickness
 
-devsim.create_2d_mesh(  mesh="mos")
+y_bulk_top = 0.0
+y_oxide_top = y_bulk_top - oxide_thickness
+y_oxide_mid = 0.5 * (y_oxide_top + y_bulk_top)
+y_gate_top = y_oxide_top - gate_thickness
+y_gate_mid = 0.5 * (y_gate_top + y_oxide_top)
+y_device_top = y_gate_top - air_thickness
+y_bulk_bottom = y_bulk_top + device_thickness
+y_bulk_mid = 0.5 * (y_bulk_top + y_bulk_bottom)
+y_device_bottom = y_bulk_bottom + air_thickness
+y_diffusion = y_bulk_top + diffusion_thickness
+
+devsim.create_2d_mesh(mesh="mos")
 devsim.add_2d_mesh_line(mesh="mos", dir="y", pos=y_device_top, ps=max_y_spacing)
 devsim.add_2d_mesh_line(mesh="mos", dir="y", pos=y_gate_top, ps=y_gate_top_spacing)
 devsim.add_2d_mesh_line(mesh="mos", dir="y", pos=y_gate_mid, ps=y_gate_mid_spacing)
-devsim.add_2d_mesh_line(mesh="mos", dir="y", pos=y_oxide_top, ps=y_gate_bot_spacing, ns=y_oxide_mid_spacing)
+devsim.add_2d_mesh_line(
+    mesh="mos", dir="y", pos=y_oxide_top, ps=y_gate_bot_spacing, ns=y_oxide_mid_spacing
+)
 devsim.add_2d_mesh_line(mesh="mos", dir="y", pos=y_oxide_mid, ps=y_oxide_mid_spacing)
-devsim.add_2d_mesh_line(mesh="mos", dir="y", pos=y_bulk_top, ns=y_oxide_mid_spacing, ps=y_channel_spacing)
+devsim.add_2d_mesh_line(
+    mesh="mos", dir="y", pos=y_bulk_top, ns=y_oxide_mid_spacing, ps=y_channel_spacing
+)
 devsim.add_2d_mesh_line(mesh="mos", dir="y", pos=y_diffusion, ps=y_diffusion_spacing)
 devsim.add_2d_mesh_line(mesh="mos", dir="y", pos=y_bulk_mid, ps=y_bulk_mid_spacing)
-devsim.add_2d_mesh_line(mesh="mos", dir="y", pos=y_bulk_bottom, ns=y_bulk_bottom_spacing, ps=max_y_spacing)
+devsim.add_2d_mesh_line(
+    mesh="mos", dir="y", pos=y_bulk_bottom, ns=y_bulk_bottom_spacing, ps=max_y_spacing
+)
 devsim.add_2d_mesh_line(mesh="mos", dir="y", pos=y_device_bottom, ps=max_y_spacing)
 
 devsim.add_2d_mesh_line(mesh="mos", dir="x", pos=x_center, ps=x_channel_spacing)
@@ -76,15 +83,71 @@ devsim.add_2d_mesh_line(mesh="mos", dir="x", pos=x_bulk_right, ps=x_diffusion_sp
 devsim.add_2d_mesh_line(mesh="mos", dir="x", pos=x_device_right, ps=max_x_spacing)
 devsim.add_2d_mesh_line(mesh="mos", dir="x", pos=x_device_left, ps=max_x_spacing)
 
-devsim.add_2d_region(mesh="mos", material="Air"    , region="air")
-devsim.add_2d_region(mesh="mos", material="Silicon", region="bulk", xl=x_bulk_left, xh=x_bulk_right, yl=y_bulk_bottom, yh=y_bulk_top)
-devsim.add_2d_region(mesh="mos", material="Silicon", region="gate", xl=x_gate_left, xh=x_gate_right, yl=y_oxide_top, yh=y_gate_top)
-devsim.add_2d_region(mesh="mos", material="Oxide"  , region="oxide", xl=x_gate_left, xh=x_gate_right, yl=y_bulk_top, yh=y_oxide_top)
+devsim.add_2d_region(mesh="mos", material="Air", region="air")
+devsim.add_2d_region(
+    mesh="mos",
+    material="Silicon",
+    region="bulk",
+    xl=x_bulk_left,
+    xh=x_bulk_right,
+    yl=y_bulk_bottom,
+    yh=y_bulk_top,
+)
+devsim.add_2d_region(
+    mesh="mos",
+    material="Silicon",
+    region="gate",
+    xl=x_gate_left,
+    xh=x_gate_right,
+    yl=y_oxide_top,
+    yh=y_gate_top,
+)
+devsim.add_2d_region(
+    mesh="mos",
+    material="Oxide",
+    region="oxide",
+    xl=x_gate_left,
+    xh=x_gate_right,
+    yl=y_bulk_top,
+    yh=y_oxide_top,
+)
 
-devsim.add_2d_contact(mesh="mos", name="gate", region="gate", yl=y_gate_top, yh=y_gate_top, material="metal")
-devsim.add_2d_contact(mesh="mos", name="body", region="bulk", yl=y_bulk_bottom, yh=y_bulk_bottom, material="metal")
-devsim.add_2d_contact(mesh="mos", name="source", region="bulk", yl=y_bulk_top, yh=y_bulk_top, xl=x_device_left, xh=x_gate_left, material="metal")
-devsim.add_2d_contact(mesh="mos", name="drain" , region="bulk", yl=y_bulk_top, yh=y_bulk_top, xl=x_gate_right, xh=x_device_right, material="metal")
+devsim.add_2d_contact(
+    mesh="mos",
+    name="gate",
+    region="gate",
+    yl=y_gate_top,
+    yh=y_gate_top,
+    material="metal",
+)
+devsim.add_2d_contact(
+    mesh="mos",
+    name="body",
+    region="bulk",
+    yl=y_bulk_bottom,
+    yh=y_bulk_bottom,
+    material="metal",
+)
+devsim.add_2d_contact(
+    mesh="mos",
+    name="source",
+    region="bulk",
+    yl=y_bulk_top,
+    yh=y_bulk_top,
+    xl=x_device_left,
+    xh=x_gate_left,
+    material="metal",
+)
+devsim.add_2d_contact(
+    mesh="mos",
+    name="drain",
+    region="bulk",
+    yl=y_bulk_top,
+    yh=y_bulk_top,
+    xl=x_gate_right,
+    xh=x_device_right,
+    material="metal",
+)
 
 devsim.add_2d_interface(mesh="mos", name="gate_oxide", region0="gate", region1="oxide")
 devsim.add_2d_interface(mesh="mos", name="bulk_oxide", region0="bulk", region1="oxide")
@@ -92,26 +155,53 @@ devsim.finalize_mesh(mesh="mos")
 devsim.create_device(mesh="mos", device=device)
 
 
-format_dict= {
-    'gate_doping' : gate_doping,
-  'source_doping' : source_doping,
-  'drain_doping' : drain_doping,
-  'body_doping' : body_doping,
-  'bulk_doping' : bulk_doping,
-  'x_gate_left' : x_gate_left,
-  'x_gate_right' : x_gate_right,
-  'x_diffusion_decay' : x_diffusion_decay,
-  'y_diffusion' : y_diffusion,
-  'y_diffusion_decay' : y_diffusion_decay,
-  'y_bulk_bottom' : y_bulk_bottom,
+format_dict = {
+    "gate_doping": gate_doping,
+    "source_doping": source_doping,
+    "drain_doping": drain_doping,
+    "body_doping": body_doping,
+    "bulk_doping": bulk_doping,
+    "x_gate_left": x_gate_left,
+    "x_gate_right": x_gate_right,
+    "x_diffusion_decay": x_diffusion_decay,
+    "y_diffusion": y_diffusion,
+    "y_diffusion_decay": y_diffusion_decay,
+    "y_bulk_bottom": y_bulk_bottom,
 }
 
-devsim.node_model(name="NetDoping"   , device=device, region="gate", equation="%(gate_doping)s" % format_dict)
-devsim.node_model(name="DrainDoping" , device=device, region="bulk", equation="0.25*%(drain_doping)s*erfc((x-%(x_gate_left)s)/%(x_diffusion_decay)s)*erfc((y-%(y_diffusion)s)/%(y_diffusion_decay)s)" % format_dict)
-devsim.node_model(name="SourceDoping", device=device, region="bulk", equation="0.25*%(source_doping)s*erfc(-(x-%(x_gate_right)s)/%(x_diffusion_decay)s)*erfc((y-%(y_diffusion)s)/%(y_diffusion_decay)s)" % format_dict)
-devsim.node_model(name="BodyDoping", device=device, region="bulk", equation="0.5*%(body_doping)s*erfc(-(y-%(y_bulk_bottom)s)/%(y_diffusion_decay)s)" % format_dict)
-devsim.node_model(name="NetDoping"   , device=device, region="bulk", equation="DrainDoping + SourceDoping + %(bulk_doping)s + BodyDoping" % format_dict)
+devsim.node_model(
+    name="NetDoping",
+    device=device,
+    region="gate",
+    equation="%(gate_doping)s" % format_dict,
+)
+devsim.node_model(
+    name="DrainDoping",
+    device=device,
+    region="bulk",
+    equation="0.25*%(drain_doping)s*erfc((x-%(x_gate_left)s)/%(x_diffusion_decay)s)*erfc((y-%(y_diffusion)s)/%(y_diffusion_decay)s)"
+    % format_dict,
+)
+devsim.node_model(
+    name="SourceDoping",
+    device=device,
+    region="bulk",
+    equation="0.25*%(source_doping)s*erfc(-(x-%(x_gate_right)s)/%(x_diffusion_decay)s)*erfc((y-%(y_diffusion)s)/%(y_diffusion_decay)s)"
+    % format_dict,
+)
+devsim.node_model(
+    name="BodyDoping",
+    device=device,
+    region="bulk",
+    equation="0.5*%(body_doping)s*erfc(-(y-%(y_bulk_bottom)s)/%(y_diffusion_decay)s)"
+    % format_dict,
+)
+devsim.node_model(
+    name="NetDoping",
+    device=device,
+    region="bulk",
+    equation="DrainDoping + SourceDoping + %(bulk_doping)s + BodyDoping" % format_dict,
+)
 
-devsim.write_devices( file="mos_2d", type="vtk")
-devsim.write_devices( file="mos_2d.flps", type="floops")
-
+devsim.write_devices(file="mos_2d", type="vtk")
+devsim.write_devices(file="mos_2d.flps", type="floops")

--- a/testing/mos_2d_restart.py
+++ b/testing/mos_2d_restart.py
@@ -6,13 +6,25 @@ import devsim
 from devsim import get_contact_list, get_region_list, set_parameter, set_node_values
 from devsim.python_packages.model_create import CreateSolution
 
+from devsim.python_packages.simple_physics import (
+    GetContactBiasName,
+    SetOxideParameters,
+    SetSiliconParameters,
+    CreateSiliconPotentialOnly,
+    CreateSiliconPotentialOnlyContact,
+    CreateSiliconDriftDiffusion,
+    CreateSiliconDriftDiffusionAtContact,
+    CreateOxidePotentialOnly,
+    CreateSiliconOxideInterface,
+)
+
 devsim.load_devices(file="mos_2d_dd.msh")
-device=devsim.get_device_list()[0]
-from devsim.python_packages.simple_physics import GetContactBiasName, SetOxideParameters, SetSiliconParameters, CreateSiliconPotentialOnly, CreateSiliconPotentialOnlyContact, CreateSiliconDriftDiffusion, CreateSiliconDriftDiffusionAtContact, CreateOxidePotentialOnly, CreateSiliconOxideInterface
+device = devsim.get_device_list()[0]
+
 
 device = "mymos"
-silicon_regions=("gate", "bulk")
-oxide_regions=("oxide",)
+silicon_regions = ("gate", "bulk")
+oxide_regions = ("oxide",)
 regions = ("gate", "bulk", "oxide")
 interfaces = ("bulk_oxide", "gate_oxide")
 
@@ -41,8 +53,10 @@ for i in interfaces:
 for i in silicon_regions:
     CreateSolution(device, i, "Electrons")
     CreateSolution(device, i, "Holes")
-    set_node_values(device=device, region=i, name="Electrons", init_from="IntrinsicElectrons")
-    set_node_values(device=device, region=i, name="Holes",     init_from="IntrinsicHoles")
+    set_node_values(
+        device=device, region=i, name="Electrons", init_from="IntrinsicElectrons"
+    )
+    set_node_values(device=device, region=i, name="Holes", init_from="IntrinsicHoles")
     CreateSiliconDriftDiffusion(device, i, "mu_n", "mu_p")
 
 for c in contacts:
@@ -50,5 +64,6 @@ for c in contacts:
     r = tmp[0]
     CreateSiliconDriftDiffusionAtContact(device, r, c)
 
-devsim.solve(type="dc", absolute_error=1.0e30, relative_error=1e-5, maximum_iterations=30)
-
+devsim.solve(
+    type="dc", absolute_error=1.0e30, relative_error=1e-5, maximum_iterations=30
+)

--- a/testing/mos_2d_restart2.py
+++ b/testing/mos_2d_restart2.py
@@ -4,18 +4,21 @@
 
 #### Plan is to use this file for full restart, including equations
 import devsim
-device="mymos"
+
+device = "mymos"
 devsim.load_devices(file="mos_2d_dd.msh")
-import mos_2d_params
+import mos_2d_params  # noqa: F401, E402
 
 devsim.set_parameter(name="debug_level", value="info")
 devsim.set_parameter(device=device, region="gate", name="debug_level", value="verbose")
 
 
-devsim.solve(type="dc", absolute_error=1.0e30, relative_error=1e-5, maximum_iterations=30)
+devsim.solve(
+    type="dc", absolute_error=1.0e30, relative_error=1e-5, maximum_iterations=30
+)
 
 
 devsim.write_devices(file="mos_2d_restart2.msh", type="devsim")
 
-#set_parameter -device mymos -region gate -name gatebias -value 0.1
-#solve -type dc -absolute_error 1.0e30 -relative_error 1e-9 -maximum_iterations 30
+# set_parameter -device mymos -region gate -name gatebias -value 0.1
+# solve -type dc -absolute_error 1.0e30 -relative_error 1e-9 -maximum_iterations 30

--- a/testing/noise_res.py
+++ b/testing/noise_res.py
@@ -15,29 +15,37 @@ res1.run_initial_bias(use_circuit_bias=True, net_doping=1e17)
 
 for v in (0.0, 1e-3):
     devsim.circuit_alter(name="V1", value=v)
-    devsim.solve(type="dc", absolute_error=1e10, relative_error=1e-7, maximum_iterations=30)
+    devsim.solve(
+        type="dc", absolute_error=1e10, relative_error=1e-7, maximum_iterations=30
+    )
     for contact in res1.contacts:
         test_common.printResistorCurrent(device=res1.device, contact=contact)
 devsim.solve(type="dc", absolute_error=1e10, relative_error=1e-7, maximum_iterations=30)
 
 devsim.solve(type="noise", frequency=1e5, output_node="V1.I")
-devsim.vector_gradient(device=res1.device, region=res1.region, node_model="V1.I_ElectronContinuityEquation_real", calc_type="avoidzero")
+devsim.vector_gradient(
+    device=res1.device,
+    region=res1.region,
+    node_model="V1.I_ElectronContinuityEquation_real",
+    calc_type="avoidzero",
+)
 for name in (
     "V1.I_ElectronContinuityEquation_real",
-  "V1.I_ElectronContinuityEquation_imag",
-  "V1.I_ElectronContinuityEquation_real_gradx",
-  "V1.I_ElectronContinuityEquation_imag_gradx",
+    "V1.I_ElectronContinuityEquation_imag",
+    "V1.I_ElectronContinuityEquation_real_gradx",
+    "V1.I_ElectronContinuityEquation_imag_gradx",
 ):
     devsim.print_node_values(device=res1.device, region=res1.region, name=name)
 
-rv="V1.I_ElectronContinuityEquation_real_gradx"
-iv="V1.I_ElectronContinuityEquation_imag_gradx"
+rv = "V1.I_ElectronContinuityEquation_real_gradx"
+iv = "V1.I_ElectronContinuityEquation_imag_gradx"
 
 for name, equation in (
     ("noisesource", "4*ElectronCharge^2 * ThermalVoltage * mu_n * Electrons"),
-  ("vfield", "(%(rv)s*%(rv)s+%(iv)s*%(iv)s)" % {'rv' : rv, 'iv' : iv}),
-  ("noise", "vec_sum(vfield * noisesource * NodeVolume)"),
+    ("vfield", "(%(rv)s*%(rv)s+%(iv)s*%(iv)s)" % {"rv": rv, "iv": iv}),
+    ("noise", "vec_sum(vfield * noisesource * NodeVolume)"),
 ):
-    devsim.node_model(device=res1.device, region=res1.region, name=name, equation=equation)
+    devsim.node_model(
+        device=res1.device, region=res1.region, name=name, equation=equation
+    )
     devsim.print_node_values(device=res1.device, region=res1.region, name=name)
-

--- a/testing/noise_res_2d.py
+++ b/testing/noise_res_2d.py
@@ -8,8 +8,8 @@ import test_common
 
 devsim.circuit_element(name="V1", n1="topbias", n2=0, acreal=1.0)
 
-device="MyDevice"
-region="MyRegion"
+device = "MyDevice"
+region = "MyRegion"
 
 ####
 #### Meshing
@@ -24,12 +24,22 @@ devsim.add_2d_mesh_line(mesh="dog", dir="y", pos=1e-5, ps=1e-6)
 devsim.add_2d_mesh_line(mesh="dog", dir="x", pos=-1e-8, ps=1e-8)
 devsim.add_2d_mesh_line(mesh="dog", dir="x", pos=1.001e-5, ps=1e-8)
 
-devsim.add_2d_region   (mesh="dog", material="Si", region=region)
-devsim.add_2d_region   (mesh="dog", material="Si", region="air1", xl=-1e-8,  xh=0)
-devsim.add_2d_region   (mesh="dog", material="Si", region="air2", xl=1.0e-5, xh=1.001e-5)
+devsim.add_2d_region(mesh="dog", material="Si", region=region)
+devsim.add_2d_region(mesh="dog", material="Si", region="air1", xl=-1e-8, xh=0)
+devsim.add_2d_region(mesh="dog", material="Si", region="air2", xl=1.0e-5, xh=1.001e-5)
 
-devsim.add_2d_contact  (mesh="dog", name="top", region=region, xl=0,    xh=0,    bloat=1e-10, material="metal")
-devsim.add_2d_contact  (mesh="dog", name="bot", region=region, xl=1e-5, xh=1e-5, bloat=1e-10, material="metal")
+devsim.add_2d_contact(
+    mesh="dog", name="top", region=region, xl=0, xh=0, bloat=1e-10, material="metal"
+)
+devsim.add_2d_contact(
+    mesh="dog",
+    name="bot",
+    region=region,
+    xl=1e-5,
+    xh=1e-5,
+    bloat=1e-10,
+    material="metal",
+)
 
 devsim.finalize_mesh(mesh="dog")
 devsim.create_device(mesh="dog", device=device)
@@ -37,40 +47,55 @@ devsim.create_device(mesh="dog", device=device)
 test_common.SetupResistorConstants(device, region)
 test_common.SetupInitialResistorSystem(device, region, net_doping=1e17)
 
-test_common.SetupInitialResistorContact(device=device, contact="top", use_circuit_bias=True, circuit_node="topbias")
-test_common.SetupInitialResistorContact(device=device, contact="bot", use_circuit_bias=False)
+test_common.SetupInitialResistorContact(
+    device=device, contact="top", use_circuit_bias=True, circuit_node="topbias"
+)
+test_common.SetupInitialResistorContact(
+    device=device, contact="bot", use_circuit_bias=False
+)
 devsim.set_parameter(name="botbias", value=0.0)
 
-devsim.solve(type='dc', absolute_error=1.0, relative_error=1e-10, maximum_iterations=30)
+devsim.solve(type="dc", absolute_error=1.0, relative_error=1e-10, maximum_iterations=30)
 
 test_common.SetupCarrierResistorSystem(device=device, region=region)
-test_common.SetupCarrierResistorContact(device=device, contact="top", use_circuit_bias=True, circuit_node="topbias")
-test_common.SetupCarrierResistorContact(device=device, contact="bot", use_circuit_bias=False)
+test_common.SetupCarrierResistorContact(
+    device=device, contact="top", use_circuit_bias=True, circuit_node="topbias"
+)
+test_common.SetupCarrierResistorContact(
+    device=device, contact="bot", use_circuit_bias=False
+)
 
 for v in (0.0, 1e-3):
     devsim.circuit_alter(name="V1", value=v)
-    devsim.solve(type='dc', absolute_error=1.0e10, relative_error=1e-7, maximum_iterations=30)
+    devsim.solve(
+        type="dc", absolute_error=1.0e10, relative_error=1e-7, maximum_iterations=30
+    )
     test_common.printResistorCurrent(device=device, contact="top")
     test_common.printResistorCurrent(device=device, contact="bot")
 
 for i in range(4):
-    devsim.solve(type='dc', absolute_error=1.0e10, relative_error=1e-7, maximum_iterations=30)
+    devsim.solve(
+        type="dc", absolute_error=1.0e10, relative_error=1e-7, maximum_iterations=30
+    )
 
 devsim.solve(type="noise", frequency=1e5, output_node="V1.I")
 
-rvx="V1.I_ElectronContinuityEquation_real_gradx"
-ivx="V1.I_ElectronContinuityEquation_imag_gradx"
-rvy="V1.I_ElectronContinuityEquation_real_grady"
-ivy="V1.I_ElectronContinuityEquation_imag_grady"
+rvx = "V1.I_ElectronContinuityEquation_real_gradx"
+ivx = "V1.I_ElectronContinuityEquation_imag_gradx"
+rvy = "V1.I_ElectronContinuityEquation_real_grady"
+ivy = "V1.I_ElectronContinuityEquation_imag_grady"
 
 for name, equation in (
     ("noisesource", "4*ElectronCharge^2 * ThermalVoltage * mu_n * Electrons"),
-  ("vfield",      "(%(rvx)s*%(rvx)s+%(ivx)s*%(ivx)s) + (%(rvy)s*%(rvy)s+%(ivy)s*%(ivy)s)" % {"rvx" : rvx, "rvy" : rvy, "ivx" : ivx, "ivy" : ivy}),
-  ("noise",       "vfield * noisesource * NodeVolume"),
+    (
+        "vfield",
+        "(%(rvx)s*%(rvx)s+%(ivx)s*%(ivx)s) + (%(rvy)s*%(rvy)s+%(ivy)s*%(ivy)s)"
+        % {"rvx": rvx, "rvy": rvy, "ivx": ivx, "ivy": ivy},
+    ),
+    ("noise", "vfield * noisesource * NodeVolume"),
 ):
     devsim.node_model(device=device, region=region, name=name, equation=equation)
 
 print(sum(devsim.get_node_model_values(device=device, region=region, name="noise")))
 
 devsim.write_devices(file="noise_res_2d.flps", type="floops")
-

--- a/testing/ptest1.py
+++ b/testing/ptest1.py
@@ -2,8 +2,19 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from devsim import create_device, get_contact_charge, get_edge_model_values, set_parameter, solve
+from devsim import (
+    create_device,
+    get_contact_charge,
+    get_edge_model_values,
+    set_parameter,
+    solve,
+)
 from cap_mesh import cap_mesh
+from devsim.python_packages.simple_physics import (
+    CreateOxideContact,
+    SetOxideParameters,
+    CreateOxidePotentialOnly,
+)
 
 region_name = "MyRegion"
 device_name = "MyDevice"
@@ -12,18 +23,31 @@ material_name = "Oxide"
 mesh_name = cap_mesh(region_name, material_name)
 create_device(mesh=mesh_name, device=device_name)
 
-from devsim.python_packages.simple_physics import CreateOxideContact, SetOxideParameters, CreateOxidePotentialOnly
-
 SetOxideParameters(device_name, region_name, 300)
 CreateOxidePotentialOnly(device_name, region_name)
 CreateOxideContact(device_name, region_name, "top")
 CreateOxideContact(device_name, region_name, "bot")
 
 set_parameter(name="bot_bias", value=0.0)
-#for i in (0.0, 1.0):
+# for i in (0.0, 1.0):
 set_parameter(name="top_bias", value=1.0)
-solve( type="dc", absolute_error= 1.0 , relative_error= 1e-10 , maximum_iterations=30)
-print((get_contact_charge(device=device_name, contact="top", equation="PotentialEquation")))
-print((get_contact_charge(device=device_name, contact="bot", equation="PotentialEquation")))
-print(get_edge_model_values(device=device_name, region=region_name, name="PotentialEdgeFlux"))
-
+solve(type="dc", absolute_error=1.0, relative_error=1e-10, maximum_iterations=30)
+print(
+    (
+        get_contact_charge(
+            device=device_name, contact="top", equation="PotentialEquation"
+        )
+    )
+)
+print(
+    (
+        get_contact_charge(
+            device=device_name, contact="bot", equation="PotentialEquation"
+        )
+    )
+)
+print(
+    get_edge_model_values(
+        device=device_name, region=region_name, name="PotentialEdgeFlux"
+    )
+)

--- a/testing/ptest2.py
+++ b/testing/ptest2.py
@@ -5,24 +5,46 @@
 ####
 #### package test for drift diffusion
 ####
-from devsim import add_1d_contact, add_1d_mesh_line, add_1d_region, create_1d_mesh, create_device, finalize_mesh, get_contact_list, get_node_model_values, set_node_values, set_parameter, solve
+from devsim import (
+    add_1d_contact,
+    add_1d_mesh_line,
+    add_1d_region,
+    create_1d_mesh,
+    create_device,
+    finalize_mesh,
+    get_contact_list,
+    get_node_model_values,
+    set_node_values,
+    set_parameter,
+    solve,
+)
 
-from devsim.python_packages.simple_physics import GetContactBiasName, PrintCurrents, SetSiliconParameters, CreateSiliconPotentialOnly, CreateSiliconPotentialOnlyContact, CreateSiliconDriftDiffusion, CreateSiliconDriftDiffusionAtContact
+from devsim.python_packages.simple_physics import (
+    GetContactBiasName,
+    PrintCurrents,
+    SetSiliconParameters,
+    CreateSiliconPotentialOnly,
+    CreateSiliconPotentialOnlyContact,
+    CreateSiliconDriftDiffusion,
+    CreateSiliconDriftDiffusionAtContact,
+)
 
-device="MyDevice"
-region="MyRegion"
+from devsim.python_packages.model_create import CreateSolution, CreateNodeModel
+
+device = "MyDevice"
+region = "MyRegion"
 
 #### TODO: make one where you pick bulk spacing, contact spacing, and junction spacing
 ####
 #### Meshing
 ####
-create_1d_mesh  (mesh="dog")
+create_1d_mesh(mesh="dog")
 add_1d_mesh_line(mesh="dog", pos=0, ps=1e-6, tag="top")
 add_1d_mesh_line(mesh="dog", pos=0.5e-5, ps=1e-7, tag="mid")
 add_1d_mesh_line(mesh="dog", pos=1e-5, ps=1e-6, tag="bot")
-add_1d_contact  (mesh="dog", name="top", tag="top", material="metal")
-add_1d_contact  (mesh="dog", name="bot", tag="bot", material="metal")
-add_1d_region   (mesh="dog", material="Si", region=region, tag1="top", tag2="bot")
+add_1d_contact(mesh="dog", name="top", tag="top", material="metal")
+add_1d_contact(mesh="dog", name="bot", tag="bot", material="metal")
+add_1d_region(mesh="dog", material="Si", region=region, tag1="top", tag2="bot")
 finalize_mesh(mesh="dog")
 create_device(mesh="dog", device=device)
 
@@ -40,9 +62,9 @@ CreateSolution(device, region, "Potential")
 #### NetDoping
 ####
 CreateNodeModel(device, region, "Acceptors", "1.0e17*step(0.5e-5-x)")
-CreateNodeModel(device, region, "Donors",    "1.0e18*step(x-0.5e-5)")
+CreateNodeModel(device, region, "Donors", "1.0e18*step(x-0.5e-5)")
 CreateNodeModel(device, region, "NetDoping", "Donors-Acceptors")
-#CreateNodeModel(device, region, "NetDoping", "1e18")
+# CreateNodeModel(device, region, "NetDoping", "1e18")
 
 CreateSiliconPotentialOnly(device, region)
 
@@ -61,21 +83,23 @@ CreateSolution(device, region, "Holes")
 ###
 ### Initialize initial guess
 ###
-set_node_values(device=device, region=region, name="Electrons", init_from="IntrinsicElectrons")
-set_node_values(device=device, region=region, name="Holes",     init_from="IntrinsicHoles")
+set_node_values(
+    device=device, region=region, name="Electrons", init_from="IntrinsicElectrons"
+)
+set_node_values(device=device, region=region, name="Holes", init_from="IntrinsicHoles")
 CreateSiliconDriftDiffusion(device, region)
 for i in get_contact_list(device=device):
     CreateSiliconDriftDiffusionAtContact(device, region, i)
 
 solve(type="dc", absolute_error=1e10, relative_error=1e-12, maximum_iterations=30)
-x= get_node_model_values(device=device, region=region, name="x")
+x = get_node_model_values(device=device, region=region, name="x")
 
-#v= get_node_model_values(device=device, region=region, name="Potential")
+# v= get_node_model_values(device=device, region=region, name="Potential")
 ##v= get_edge_model_values(device=device, region=region, name="ElectricField")
-#import matplotlib
-#import matplotlib.pyplot
-#matplotlib.pyplot.plot(v)
-#matplotlib.pyplot.savefig('foo.pdf')
+# import matplotlib
+# import matplotlib.pyplot
+# matplotlib.pyplot.plot(v)
+# matplotlib.pyplot.savefig('foo.pdf')
 
 v = 0.1
 while v < 0.99:
@@ -84,6 +108,3 @@ while v < 0.99:
     PrintCurrents(device, "top")
     PrintCurrents(device, "bot")
     v += 0.1
-
-
-

--- a/testing/pythonmesh1d.py
+++ b/testing/pythonmesh1d.py
@@ -1,29 +1,41 @@
-
-from devsim import add_gmsh_contact, add_gmsh_interface, add_gmsh_region, create_device, create_gmsh_mesh, finalize_mesh, get_contact_list, get_element_node_list, get_interface_list, get_node_model_values, get_region_list, write_devices
+from devsim import (
+    add_gmsh_contact,
+    add_gmsh_interface,
+    add_gmsh_region,
+    create_device,
+    create_gmsh_mesh,
+    finalize_mesh,
+    get_contact_list,
+    get_element_node_list,
+    get_interface_list,
+    get_node_model_values,
+    get_region_list,
+    write_devices,
+)
 
 import itertools
 
 print("coordinates")
-coordinates=[]
-for i in range(0,11):
+coordinates = []
+for i in range(0, 11):
     coordinates.extend([float(i), 0.0, 0.0])
 print(coordinates)
 print()
 
 print("elements")
-elements=[]
-for i in range(0,5):
+elements = []
+for i in range(0, 5):
     # line type, physical region 0
-    x=[1, 0, i, i+1]
+    x = [1, 0, i, i + 1]
     print(x)
     elements.extend(x)
-for i in range(5,10):
+for i in range(5, 10):
     # line type, physical region 1
-    x=[1, 1, i, i+1]
+    x = [1, 1, i, i + 1]
     print(x)
-    elements.extend([1, 1, i, i+1])
+    elements.extend([1, 1, i, i + 1])
 
-#points for boundary conditions
+# points for boundary conditions
 elements.extend([0, 2, 0])
 print(elements[-3:])
 elements.extend([0, 3, 10])
@@ -33,25 +45,43 @@ print(elements[-3:])
 print()
 
 print("physical_names")
-physical_names = [
-  "top",
-  "bot",
-  "top_contact",
-  "bot_contact",
-  "top_bot_interface"
-]
+physical_names = ["top", "bot", "top_contact", "bot_contact", "top_bot_interface"]
 print(physical_names)
 print()
 
-create_gmsh_mesh(mesh="toy", coordinates=coordinates, physical_names=physical_names, elements=elements)
+create_gmsh_mesh(
+    mesh="toy",
+    coordinates=coordinates,
+    physical_names=physical_names,
+    elements=elements,
+)
 add_gmsh_region(mesh="toy", gmsh_name="top", region="top", material="silicon")
 add_gmsh_region(mesh="toy", gmsh_name="bot", region="bot", material="silicon")
-add_gmsh_contact(mesh="toy", gmsh_name="top_contact", name="top_contact", region="top", material="metal")
-add_gmsh_contact(mesh="toy", gmsh_name="bot_contact", name="bot_contact", region="bot", material="metal")
-add_gmsh_interface(mesh="toy", gmsh_name="top_bot_interface", name="top_bot_interface", region0="top", region1="bot")
+add_gmsh_contact(
+    mesh="toy",
+    gmsh_name="top_contact",
+    name="top_contact",
+    region="top",
+    material="metal",
+)
+add_gmsh_contact(
+    mesh="toy",
+    gmsh_name="bot_contact",
+    name="bot_contact",
+    region="bot",
+    material="metal",
+)
+add_gmsh_interface(
+    mesh="toy",
+    gmsh_name="top_bot_interface",
+    name="top_bot_interface",
+    region0="top",
+    region1="bot",
+)
 finalize_mesh(mesh="toy")
 create_device(mesh="toy", device="toy")
-write_devices(device="toy",file="pythonmesh1d.msh")
+write_devices(device="toy", file="pythonmesh1d.msh")
+
 
 class MeshWriter:
     def __init__(self, device):
@@ -64,7 +94,6 @@ class MeshWriter:
         self.region_to_coordinate_indexes = {}
         self.name_to_physical_index = {}
 
-
     def get_element_list(self, shapes, physical_index, region_coordinate_indexes):
         # Element Type (float)
         #     0 node
@@ -73,47 +102,57 @@ class MeshWriter:
         #     3 tetrahedron
         element_list = []
         for shape in shapes:
-            element_list.append(len(shape)-1)
+            element_list.append(len(shape) - 1)
             element_list.append(physical_index)
             element_list.extend([region_coordinate_indexes[i] for i in shape])
         return element_list
-
-
 
     def get_global_coordinates(self):
         # this is the global list of coordinates
 
         for r in get_region_list(device=self.device):
-          region_coordinates = [int(x) for x in get_node_model_values(device=self.device, region=r, name='coordinate_index')]
-          self.region_to_coordinate_indexes[r] = region_coordinates
+            region_coordinates = [
+                int(x)
+                for x in get_node_model_values(
+                    device=self.device, region=r, name="coordinate_index"
+                )
+            ]
+            self.region_to_coordinate_indexes[r] = region_coordinates
 
-          # expand global coordinate list as necessary
-          clen = max(region_coordinates) + 1
-          if clen > len(self.coordinates_xyz):
-            self.coordinates_xyz.extend([None] * (clen - len(self.coordinates_xyz)))
+            # expand global coordinate list as necessary
+            clen = max(region_coordinates) + 1
+            if clen > len(self.coordinates_xyz):
+                self.coordinates_xyz.extend([None] * (clen - len(self.coordinates_xyz)))
 
-          node_positions = zip(get_node_model_values(device=self.device, region=r, name='x'),
-                               get_node_model_values(device=self.device, region=r, name='y'),
-                               get_node_model_values(device=self.device, region=r, name='z'))
+            node_positions = zip(
+                get_node_model_values(device=self.device, region=r, name="x"),
+                get_node_model_values(device=self.device, region=r, name="y"),
+                get_node_model_values(device=self.device, region=r, name="z"),
+            )
 
-          for i, p in enumerate(node_positions):
-              self.coordinates_xyz[region_coordinates[i]] = p
+            for i, p in enumerate(node_positions):
+                self.coordinates_xyz[region_coordinates[i]] = p
 
         self.coordinates = list(itertools.chain.from_iterable(self.coordinates_xyz))
-
 
     def get_elements(self):
         for r in get_region_list(device=self.device):
             rtc = self.region_to_coordinate_indexes[r]
             physical_index = self.name_to_physical_index[r]
-            elist = self.get_element_list(get_element_node_list(device=self.device, region=r), physical_index, rtc)
+            elist = self.get_element_list(
+                get_element_node_list(device=self.device, region=r), physical_index, rtc
+            )
             self.elements.extend(elist)
 
         for c in get_contact_list(device=self.device):
             r = get_region_list(device=self.device, contact=c)[0]
             rtc = self.region_to_coordinate_indexes[r]
             physical_index = self.name_to_physical_index[c]
-            elist = self.get_element_list(get_element_node_list(device=self.device, region=r, contact=c), physical_index, rtc)
+            elist = self.get_element_list(
+                get_element_node_list(device=self.device, region=r, contact=c),
+                physical_index,
+                rtc,
+            )
             self.elements.extend(elist)
 
         # warning, this will not work for the special periodic boundary condition
@@ -122,15 +161,19 @@ class MeshWriter:
             for r in get_region_list(device=self.device, interface=i):
                 rtc = self.region_to_coordinate_indexes[r]
                 physical_index = self.name_to_physical_index[i]
-                elist = self.get_element_list(get_element_node_list(device=self.device, region=r, interface=i), physical_index, rtc)
+                elist = self.get_element_list(
+                    get_element_node_list(device=self.device, region=r, interface=i),
+                    physical_index,
+                    rtc,
+                )
                 elists.append(elist)
             if elists[0] != elists[1]:
-                raise RuntimeError(f"Error processing interface {i}.  If you are using the periodic interface boundary condition, then please contact support for modifying script.")
+                raise RuntimeError(
+                    f"Error processing interface {i}.  If you are using the periodic interface boundary condition, then please contact support for modifying script."
+                )
             self.elements.extend(elists[0])
 
-
     def populate_physical_names(self):
-
         def add_name(name):
             if name in self.name_to_physical_index:
                 raise RuntimeError(f"Cannot use name {name} twice")

--- a/testing/res1.py
+++ b/testing/res1.py
@@ -5,52 +5,61 @@
 import devsim
 import test_common
 
-device="MyDevice"
-region="MyRegion"
-contacts=('top', 'bot')
+device = "MyDevice"
+region = "MyRegion"
+contacts = ("top", "bot")
+
 
 def run_initial_bias(use_circuit_bias, net_doping=1e16):
-    '''
-      use_circuit for topbias
-    '''
+    """
+    use_circuit for topbias
+    """
     test_common.SetupResistorConstants(device, region)
     test_common.SetupInitialResistorSystem(device, region, net_doping)
-    test_common.SetupInitialResistorContact(device=device, contact='top', use_circuit_bias=use_circuit_bias)
-    test_common.SetupInitialResistorContact(device=device, contact='bot')
+    test_common.SetupInitialResistorContact(
+        device=device, contact="top", use_circuit_bias=use_circuit_bias
+    )
+    test_common.SetupInitialResistorContact(device=device, contact="bot")
 
     #####
     ##### Initial DC Solution
     #####
-    devsim.solve(type='dc', absolute_error=1.0, relative_error=1e-10, maximum_iterations=30)
+    devsim.solve(
+        type="dc", absolute_error=1.0, relative_error=1e-10, maximum_iterations=30
+    )
 
     for name in ("Potential", "IntrinsicElectrons"):
         devsim.print_node_values(device=device, region=region, name=name)
 
     test_common.SetupCarrierResistorSystem(device, region)
-    test_common.SetupCarrierResistorContact(device=device, contact='top', use_circuit_bias=use_circuit_bias)
-    test_common.SetupCarrierResistorContact(device, contact='bot')
+    test_common.SetupCarrierResistorContact(
+        device=device, contact="top", use_circuit_bias=use_circuit_bias
+    )
+    test_common.SetupCarrierResistorContact(device, contact="bot")
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     test_common.CreateSimpleMesh(device, region)
     devsim.set_parameter(name="topbias", value=0.0)
     devsim.set_parameter(name="botbias", value=0.0)
     run_initial_bias(False)
     for v in (0.0, 0.01, 0.02, 0.03, 0.04, 0.05, 0.06, 0.07, 0.08, 0.09, 0.10):
         devsim.set_parameter(name="topbias", value=v)
-        devsim.solve(type="dc", absolute_error=1.0, relative_error=1e-10, maximum_iterations=30)
+        devsim.solve(
+            type="dc", absolute_error=1.0, relative_error=1e-10, maximum_iterations=30
+        )
 
-        test_common.printResistorCurrent(device=device, contact='top')
-        test_common.printResistorCurrent(device=device, contact='bot')
+        test_common.printResistorCurrent(device=device, contact="top")
+        test_common.printResistorCurrent(device=device, contact="bot")
 
     devsim.print_node_values(device=device, region=region, name="Electrons")
     devsim.print_node_values(device=device, region=region, name="Potential")
     devsim.print_edge_values(device=device, region=region, name="ElectricField")
     devsim.print_edge_values(device=device, region=region, name="ElectronCurrent")
 
-    l=1.0
-    q=1.6e-19
-    n=1.0e16
-    u=400
-    R=l/(q*n*u)
-    print(0.1/R)
-
+    l = 1.0  # noqa: E741
+    q = 1.6e-19
+    n = 1.0e16
+    u = 400
+    R = l / (q * n * u)
+    print(0.1 / R)

--- a/testing/res2.py
+++ b/testing/res2.py
@@ -5,12 +5,14 @@
 import devsim
 import test_common
 
-device='MyDevice'
-regions=('MySi1', 'MySi2')
-interface='MyInt'
-contacts=('top', 'bot')
+device = "MyDevice"
+regions = ("MySi1", "MySi2")
+interface = "MyInt"
+contacts = ("top", "bot")
 
-test_common.CreateSimpleMeshWithInterface(device=device, region0=regions[0], region1=regions[1], interface=interface)
+test_common.CreateSimpleMeshWithInterface(
+    device=device, region0=regions[0], region1=regions[1], interface=interface
+)
 
 for region in regions:
     test_common.SetupResistorConstants(device, region)
@@ -26,7 +28,7 @@ test_common.SetupContinuousPotentialAtInterface(device, interface)
 #####
 devsim.set_parameter(name="topbias", value=0.0)
 devsim.set_parameter(name="botbias", value=0.0)
-devsim.solve(type='dc', absolute_error=1.0, relative_error=1e-10, maximum_iterations=30)
+devsim.solve(type="dc", absolute_error=1.0, relative_error=1e-10, maximum_iterations=30)
 
 for region in regions:
     for name in ("Potential", "IntrinsicElectrons"):
@@ -42,10 +44,12 @@ test_common.SetupContinuousElectronsAtInterface(device, interface)
 
 for v in (0.0, 0.01, 0.02, 0.03, 0.04, 0.05, 0.06, 0.07, 0.08, 0.09, 0.10):
     devsim.set_parameter(name="topbias", value=v)
-    devsim.solve(type="dc", absolute_error=1.0, relative_error=1e-10, maximum_iterations=30)
+    devsim.solve(
+        type="dc", absolute_error=1.0, relative_error=1e-10, maximum_iterations=30
+    )
 
-    test_common.printResistorCurrent(device=device, contact='top')
-    test_common.printResistorCurrent(device=device, contact='bot')
+    test_common.printResistorCurrent(device=device, contact="top")
+    test_common.printResistorCurrent(device=device, contact="bot")
 
 for region in regions:
     devsim.print_node_values(device=device, region=region, name="Electrons")
@@ -53,10 +57,9 @@ for region in regions:
     devsim.print_edge_values(device=device, region=region, name="ElectricField")
     devsim.print_edge_values(device=device, region=region, name="ElectronCurrent")
 
-l=1.0
-q=1.6e-19
-n=1.0e16
-u=400
-R=l/(q*n*u)
-print(0.1/R)
-
+l = 1.0  # noqa: E741
+q = 1.6e-19
+n = 1.0e16
+u = 400
+R = l / (q * n * u)
+print(0.1 / R)

--- a/testing/res3.py
+++ b/testing/res3.py
@@ -5,12 +5,14 @@
 import devsim
 import test_common
 
-device='MyDevice'
-regions=('MySi1', 'MySi2')
-interface='MyInt'
-contacts=('top', 'bot')
+device = "MyDevice"
+regions = ("MySi1", "MySi2")
+interface = "MyInt"
+contacts = ("top", "bot")
 
-test_common.CreateSimpleMeshWithInterface(device=device, region0=regions[0], region1=regions[1], interface=interface)
+test_common.CreateSimpleMeshWithInterface(
+    device=device, region0=regions[0], region1=regions[1], interface=interface
+)
 
 for region in regions:
     test_common.SetupResistorConstants(device, region)
@@ -26,7 +28,7 @@ test_common.SetupContinuousPotentialAtInterface(device, interface)
 #####
 devsim.set_parameter(name="topbias", value=0.0)
 devsim.set_parameter(name="botbias", value=0.0)
-devsim.solve(type='dc', absolute_error=1.0, relative_error=1e-10, maximum_iterations=30)
+devsim.solve(type="dc", absolute_error=1.0, relative_error=1e-10, maximum_iterations=30)
 
 for region in regions:
     for name in ("Potential", "IntrinsicElectrons"):
@@ -43,14 +45,15 @@ test_common.SetupElectronSRVAtInterface(device, interface)
 
 for v in (0.0, 0.01, 0.02, 0.03, 0.04, 0.05, 0.06, 0.07, 0.08, 0.09, 0.10):
     devsim.set_parameter(name="topbias", value=v)
-    devsim.solve(type="dc", absolute_error=1.0, relative_error=1e-10, maximum_iterations=30)
+    devsim.solve(
+        type="dc", absolute_error=1.0, relative_error=1e-10, maximum_iterations=30
+    )
 
-    test_common.printResistorCurrent(device=device, contact='top')
-    test_common.printResistorCurrent(device=device, contact='bot')
+    test_common.printResistorCurrent(device=device, contact="top")
+    test_common.printResistorCurrent(device=device, contact="bot")
 
 for region in regions:
     devsim.print_node_values(device=device, region=region, name="Electrons")
     devsim.print_node_values(device=device, region=region, name="Potential")
     devsim.print_edge_values(device=device, region=region, name="ElectricField")
     devsim.print_edge_values(device=device, region=region, name="ElectronCurrent")
-

--- a/testing/rundifftest.py
+++ b/testing/rundifftest.py
@@ -11,11 +11,13 @@ import subprocess
 
 parser = argparse.ArgumentParser()
 
-parser.add_argument('--testexe',      help="binary to test", required=False)
-parser.add_argument('--goldendir',    help="golden results directory", required=True)
-parser.add_argument('--working',      help="working directory", required=False, default="")
-parser.add_argument('--output',       help="output filename to compare with goldenresult", required=True)
-parser.add_argument('--args',         help="list of input arguments", nargs='+', required=False)
+parser.add_argument("--testexe", help="binary to test", required=False)
+parser.add_argument("--goldendir", help="golden results directory", required=True)
+parser.add_argument("--working", help="working directory", required=False, default="")
+parser.add_argument(
+    "--output", help="output filename to compare with goldenresult", required=True
+)
+parser.add_argument("--args", help="list of input arguments", nargs="+", required=False)
 args = parser.parse_args()
 
 if args.working:
@@ -31,31 +33,30 @@ else:
 if output_file == compare_file:
     raise RuntimeError("output and golden file cannot be the same file " + output_file)
 
-if (args.working):
+if args.working:
     os.chdir(args.working)
 if args.testexe:
-    arguments = [args.testexe,]
+    arguments = [
+        args.testexe,
+    ]
     if args.args:
         arguments.extend(args.args)
-    with open(output_file, 'w') as ofile:
-        process = subprocess.run(
-            arguments,
-            stdout = ofile,
-            stderr = subprocess.STDOUT
-        )
+    with open(output_file, "w") as ofile:
+        process = subprocess.run(arguments, stdout=ofile, stderr=subprocess.STDOUT)
         if process.returncode != 0:
-            raise RuntimeError("%s returned error code %d" % (args.testexe, process.returncode))
+            raise RuntimeError(
+                "%s returned error code %d" % (args.testexe, process.returncode)
+            )
 
 f1stat = os.stat(output_file)
 f2stat = os.stat(compare_file)
 
 with open(output_file) as f1:
     with open(compare_file) as f2:
-        while (True):
+        while True:
             a1 = next(f1, "SENTINELlkj")
             a2 = next(f2, "SENTINELlkj")
             if a1 != a2:
                 raise RuntimeError("%s differs from %s" % (output_file, compare_file))
             elif a1 == "SENTINELlkj":
                 break
-

--- a/testing/sqlite2.py
+++ b/testing/sqlite2.py
@@ -2,22 +2,28 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-#puts [package require sqlite3]
+# puts [package require sqlite3]
 # setting an index on material or parameter?
 
-#sqlite3 db1 ./testdb
-#db1 eval {DROP TABLE IF EXISTS t1}
-#db1 eval {CREATE TABLE t1(material text, parameter text, value real, unit text, description text)}
+# sqlite3 db1 ./testdb
+# db1 eval {DROP TABLE IF EXISTS t1}
+# db1 eval {CREATE TABLE t1(material text, parameter text, value real, unit text, description text)}
 #
-#set x [db1 eval {INSERT INTO t1 VALUES('global', 'q',  '1.60217646e-19', 'coul', 'Electron Charge')}];
-#set x [db1 eval {INSERT INTO t1 VALUES('global', 'pi', '3.14159265358979323846', '', 'Pi')}];
-#set x [db1 eval {INSERT INTO t1 VALUES('global', 'm0', '9.10938188e-31', 'kg', 'Electron Mass')}];
-#set x [db1 eval {SELECT * FROM t1 ORDER BY material}]
-#puts $x
+# set x [db1 eval {INSERT INTO t1 VALUES('global', 'q',  '1.60217646e-19', 'coul', 'Electron Charge')}];
+# set x [db1 eval {INSERT INTO t1 VALUES('global', 'pi', '3.14159265358979323846', '', 'Pi')}];
+# set x [db1 eval {INSERT INTO t1 VALUES('global', 'm0', '9.10938188e-31', 'kg', 'Electron Mass')}];
+# set x [db1 eval {SELECT * FROM t1 ORDER BY material}]
+# puts $x
 from devsim import add_db_entry, close_db, create_db, get_db_entry, open_db, save_db
 
 create_db(filename="foodb")
-add_db_entry(material="global", parameter="q", value=1.60217646e-19, unit="coul", description="Electron Charge")
+add_db_entry(
+    material="global",
+    parameter="q",
+    value=1.60217646e-19,
+    unit="coul",
+    description="Electron Charge",
+)
 add_db_entry(material="global", parameter="one", value=2, unit="", description="")
 print((get_db_entry(material="global", parameter="q")))
 print((get_db_entry(material="global", parameter="one")))

--- a/testing/sqlite3.py
+++ b/testing/sqlite3.py
@@ -2,38 +2,62 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from devsim import add_1d_contact, add_1d_mesh_line, add_1d_region, add_db_entry, create_1d_mesh, create_db, create_device, finalize_mesh, get_material, node_model, print_node_values, set_material
+from devsim import (
+    add_1d_contact,
+    add_1d_mesh_line,
+    add_1d_region,
+    add_db_entry,
+    create_1d_mesh,
+    create_db,
+    create_device,
+    finalize_mesh,
+    get_material,
+    node_model,
+    print_node_values,
+    set_material,
+)
 
-#print region_info
-device ="d1"
-region ="r1"
+# print region_info
+device = "d1"
+region = "r1"
 
 create_1d_mesh(mesh="dog")
 for p, s, t in ((0.0, 0.1, "top"), (1.0, 0.1, "bot")):
-    add_1d_mesh_line(mesh ="dog", pos=p, ps = s, tag = t)
+    add_1d_mesh_line(mesh="dog", pos=p, ps=s, tag=t)
 
-for t in ('top', 'bot'):
-    add_1d_contact(  mesh ="dog", name=t, tag=t, material="metal")
+for t in ("top", "bot"):
+    add_1d_contact(mesh="dog", name=t, tag=t, material="metal")
 
-add_1d_region(   mesh ="dog", material="Si", region = region, tag1 ="top" , tag2 ="bot")
+add_1d_region(mesh="dog", material="Si", region=region, tag1="top", tag2="bot")
 finalize_mesh(mesh="dog")
-create_device(mesh="dog", device = device)
+create_device(mesh="dog", device=device)
 
-#avoid contention with sqlite2 test
+# avoid contention with sqlite2 test
 create_db(filename="foodb2")
-add_db_entry(material="global", parameter="q"  , value=1.60217646e-19, unit="coul", description="Electron Charge")
-add_db_entry(material="Si"    , parameter="one", value=1             , unit=""    , description="")
+add_db_entry(
+    material="global",
+    parameter="q",
+    value=1.60217646e-19,
+    unit="coul",
+    description="Electron Charge",
+)
+add_db_entry(material="Si", parameter="one", value=1, unit="", description="")
 
 node_model(device=device, region=region, name="test", equation="one * q")
 
 print_node_values(device=device, region=region, name="test")
 
-add_db_entry(material="global", parameter="q", value=2, unit="coul", description="Electron Charge")
-print_node_values (device=device, region=region, name="test")
+add_db_entry(
+    material="global",
+    parameter="q",
+    value=2,
+    unit="coul",
+    description="Electron Charge",
+)
+print_node_values(device=device, region=region, name="test")
 add_db_entry(material="Si", parameter="one", value=3, unit="", description="")
 print(("Material: %s" % get_material(device=device, region=region)))
-print_node_values (device=device, region=region, name="test")
+print_node_values(device=device, region=region, name="test")
 set_material(device=device, region=region, material="Ox")
 add_db_entry(material="Ox", parameter="one", value=4, unit="", description="")
-print_node_values (device=device, region=region, name="test")
-
+print_node_values(device=device, region=region, name="test")

--- a/testing/ssac_cap.py
+++ b/testing/ssac_cap.py
@@ -6,15 +6,17 @@
 import devsim
 import test_common
 
-device="MyDevice"
-region="MyRegion"
+device = "MyDevice"
+region = "MyRegion"
 
 test_common.CreateSimpleMesh(device, region)
 
 ###
 ### Set parameters on the region
 ###
-devsim.set_parameter(device=device, region=region, name="Permittivity", value=3.9*8.85e-14)
+devsim.set_parameter(
+    device=device, region=region, name="Permittivity", value=3.9 * 8.85e-14
+)
 
 ###
 ### Create the Potential solution variable
@@ -30,56 +32,94 @@ devsim.edge_from_node_model(device=device, region=region, node_model="Potential"
 ### Electric field on each edge, as well as its derivatives with respect to
 ### the potential at each node
 ###
-devsim.edge_model(device=device, region=region, name="ElectricField",
-                  equation="(Potential@n0 - Potential@n1)*EdgeInverseLength")
+devsim.edge_model(
+    device=device,
+    region=region,
+    name="ElectricField",
+    equation="(Potential@n0 - Potential@n1)*EdgeInverseLength",
+)
 
-devsim.edge_model(device=device, region=region, name="ElectricField:Potential@n0",
-                  equation="EdgeInverseLength")
+devsim.edge_model(
+    device=device,
+    region=region,
+    name="ElectricField:Potential@n0",
+    equation="EdgeInverseLength",
+)
 
-devsim.edge_model(device=device, region=region, name="ElectricField:Potential@n1",
-                  equation="-EdgeInverseLength")
+devsim.edge_model(
+    device=device,
+    region=region,
+    name="ElectricField:Potential@n1",
+    equation="-EdgeInverseLength",
+)
 
 ###
 ### Model the D Field
 ###
-devsim.edge_model(device=device, region=region, name="DField",
-                  equation="Permittivity*ElectricField")
+devsim.edge_model(
+    device=device, region=region, name="DField", equation="Permittivity*ElectricField"
+)
 
-devsim.edge_model(device=device, region=region, name="DField:Potential@n0",
-                  equation="diff(Permittivity*ElectricField, Potential@n0)")
+devsim.edge_model(
+    device=device,
+    region=region,
+    name="DField:Potential@n0",
+    equation="diff(Permittivity*ElectricField, Potential@n0)",
+)
 
-devsim.edge_model(device=device, region=region, name="DField:Potential@n1",
-                  equation="-DField:Potential@n0")
+devsim.edge_model(
+    device=device,
+    region=region,
+    name="DField:Potential@n1",
+    equation="-DField:Potential@n0",
+)
 
 ###
 ### Create the bulk equation
 ###
-devsim.equation(device=device, region=region, name="PotentialEquation", variable_name="Potential",
-                edge_model="DField", variable_update="default")
+devsim.equation(
+    device=device,
+    region=region,
+    name="PotentialEquation",
+    variable_name="Potential",
+    edge_model="DField",
+    variable_update="default",
+)
 
 # the topbias is a circuit node, and we want to prevent it from being overridden by a parameter
 devsim.set_parameter(device=device, region=region, name="botbias", value=0.0)
 
 for name, equation in (
     ("topnode_model", "Potential - topbias"),
-  ("topnode_model:Potential", "1"),
-  ("topnode_model:topbias", "-1"),
-  ("botnode_model", "Potential - botbias"),
-  ("botnode_model:Potential", "1"),
+    ("topnode_model:Potential", "1"),
+    ("topnode_model:topbias", "-1"),
+    ("botnode_model", "Potential - botbias"),
+    ("botnode_model:Potential", "1"),
 ):
     devsim.node_model(device=device, region=region, name=name, equation=equation)
 
 # attached to circuit node
-devsim.contact_equation(device=device, contact="top", name="PotentialEquation",
-                        node_model="topnode_model", edge_charge_model="DField", circuit_node="topbias")
+devsim.contact_equation(
+    device=device,
+    contact="top",
+    name="PotentialEquation",
+    node_model="topnode_model",
+    edge_charge_model="DField",
+    circuit_node="topbias",
+)
 # attached to ground
-devsim.contact_equation(device=device, contact="bot", name="PotentialEquation",
-                        node_model="botnode_model", edge_charge_model="DField")
+devsim.contact_equation(
+    device=device,
+    contact="bot",
+    name="PotentialEquation",
+    node_model="botnode_model",
+    edge_charge_model="DField",
+)
 
 #
 # Voltage source
 #
-devsim.circuit_element(name="V1", n1=1,         n2=0, value=1.0, acreal=1.0)
+devsim.circuit_element(name="V1", n1=1, n2=0, value=1.0, acreal=1.0)
 devsim.circuit_element(name="R1", n1="topbias", n2=1, value=1e3)
 
 #
@@ -87,12 +127,19 @@ devsim.solve(type="dc", absolute_error=1.0, relative_error=1e-10, maximum_iterat
 
 test_common.print_circuit_solution()
 #
-print(devsim.get_contact_charge(device=device, contact="top", equation="PotentialEquation"))
-print(devsim.get_contact_charge(device=device, contact="bot", equation="PotentialEquation"))
+print(
+    devsim.get_contact_charge(
+        device=device, contact="top", equation="PotentialEquation"
+    )
+)
+print(
+    devsim.get_contact_charge(
+        device=device, contact="bot", equation="PotentialEquation"
+    )
+)
 #
 devsim.solve(type="ac", frequency=1e10)
 test_common.print_ac_circuit_solution()
 
 devsim.solve(type="ac", frequency=1e15)
 test_common.print_ac_circuit_solution()
-

--- a/testing/ssac_cap_2d_edge.py
+++ b/testing/ssac_cap_2d_edge.py
@@ -6,55 +6,67 @@
 import devsim
 import test_common
 
-device="MyDevice"
-region="MyRegion"
+device = "MyDevice"
+region = "MyRegion"
 
-xmin=-25
-x1  =-24.975
-x2  =-2
-x3  =2
-x4  =24.975
-xmax=25.0
+xmin = -25
+x1 = -24.975
+x2 = -2
+x3 = 2
+x4 = 24.975
+xmax = 25.0
 
-ymin=0.0
-y1  =0.1
-y2  =0.2
-y3  =0.8
-y4  =0.9
-ymax=50.0
+ymin = 0.0
+y1 = 0.1
+y2 = 0.2
+y3 = 0.8
+y4 = 0.9
+ymax = 50.0
 
 devsim.create_2d_mesh(mesh=device)
 devsim.add_2d_mesh_line(mesh=device, dir="y", pos=ymin, ps=0.1)
-devsim.add_2d_mesh_line(mesh=device, dir="y", pos=y1  , ps=0.1)
-devsim.add_2d_mesh_line(mesh=device, dir="y", pos=y2  , ps=0.1)
-devsim.add_2d_mesh_line(mesh=device, dir="y", pos=y3  , ps=0.1)
-devsim.add_2d_mesh_line(mesh=device, dir="y", pos=y4  , ps=0.1)
+devsim.add_2d_mesh_line(mesh=device, dir="y", pos=y1, ps=0.1)
+devsim.add_2d_mesh_line(mesh=device, dir="y", pos=y2, ps=0.1)
+devsim.add_2d_mesh_line(mesh=device, dir="y", pos=y3, ps=0.1)
+devsim.add_2d_mesh_line(mesh=device, dir="y", pos=y4, ps=0.1)
 devsim.add_2d_mesh_line(mesh=device, dir="y", pos=ymax, ps=5.0)
 
-device=device
-region="air"
+device = device
+region = "air"
 
 devsim.add_2d_mesh_line(mesh=device, dir="x", pos=xmin, ps=5)
-devsim.add_2d_mesh_line(mesh=device, dir="x", pos=x1  , ps=2)
-devsim.add_2d_mesh_line(mesh=device, dir="x", pos=x2  , ps=0.05)
-devsim.add_2d_mesh_line(mesh=device, dir="x", pos=x3  , ps=0.05)
-devsim.add_2d_mesh_line(mesh=device, dir="x", pos=x4  , ps=2)
+devsim.add_2d_mesh_line(mesh=device, dir="x", pos=x1, ps=2)
+devsim.add_2d_mesh_line(mesh=device, dir="x", pos=x2, ps=0.05)
+devsim.add_2d_mesh_line(mesh=device, dir="x", pos=x3, ps=0.05)
+devsim.add_2d_mesh_line(mesh=device, dir="x", pos=x4, ps=2)
 devsim.add_2d_mesh_line(mesh=device, dir="x", pos=xmax, ps=5)
 
-devsim.add_2d_region(mesh=device, material="gas"  , region="air", yl=ymin, yh=ymax, xl=xmin, xh=xmax)
-devsim.add_2d_region(mesh=device, material="metal", region="m1" , yl=y1  , yh=y2  , xl=x1  , xh=x4)
-devsim.add_2d_region(mesh=device, material="metal", region="m2" , yl=y3  , yh=y4  , xl=x2  , xh=x3)
+devsim.add_2d_region(
+    mesh=device, material="gas", region="air", yl=ymin, yh=ymax, xl=xmin, xh=xmax
+)
+devsim.add_2d_region(
+    mesh=device, material="metal", region="m1", yl=y1, yh=y2, xl=x1, xh=x4
+)
+devsim.add_2d_region(
+    mesh=device, material="metal", region="m2", yl=y3, yh=y4, xl=x2, xh=x3
+)
 
 # must be air since contacts don't have any equations
-devsim.add_2d_contact(mesh=device, name="bot", region="air", yl=y1, yh=y2, xl=x1, xh=x4, material="metal")
-devsim.add_2d_contact(mesh=device, name="top", region="air", yl=y3, yh=y4, xl=x2, xh=x3, material="metal")
+devsim.add_2d_contact(
+    mesh=device, name="bot", region="air", yl=y1, yh=y2, xl=x1, xh=x4, material="metal"
+)
+devsim.add_2d_contact(
+    mesh=device, name="top", region="air", yl=y3, yh=y4, xl=x2, xh=x3, material="metal"
+)
 devsim.finalize_mesh(mesh=device)
 devsim.create_device(mesh=device, device=device)
 
 ###
 ### Set parameters on the region
 ###
-devsim.set_parameter(device=device, region=region, name="Permittivity", value=3.9*8.85e-14)
+devsim.set_parameter(
+    device=device, region=region, name="Permittivity", value=3.9 * 8.85e-14
+)
 
 ###
 ### Create the Potential solution variable
@@ -70,64 +82,110 @@ devsim.edge_from_node_model(device=device, region=region, node_model="Potential"
 ### Electric field on each edge, as well as its derivatives with respect to
 ### the potential at each node
 ###
-devsim.edge_model(device=device, region=region, name="ElectricField",
-                  equation="(Potential@n0 - Potential@n1)*EdgeInverseLength")
+devsim.edge_model(
+    device=device,
+    region=region,
+    name="ElectricField",
+    equation="(Potential@n0 - Potential@n1)*EdgeInverseLength",
+)
 
-devsim.edge_model(device=device, region=region, name="ElectricField:Potential@n0",
-                  equation="EdgeInverseLength")
+devsim.edge_model(
+    device=device,
+    region=region,
+    name="ElectricField:Potential@n0",
+    equation="EdgeInverseLength",
+)
 
-devsim.edge_model(device=device, region=region, name="ElectricField:Potential@n1",
-                  equation="-EdgeInverseLength")
+devsim.edge_model(
+    device=device,
+    region=region,
+    name="ElectricField:Potential@n1",
+    equation="-EdgeInverseLength",
+)
 
 ###
 ### Model the D Field
 ###
-devsim.edge_model(device=device, region=region, name="DField",
-                  equation="Permittivity*ElectricField")
+devsim.edge_model(
+    device=device, region=region, name="DField", equation="Permittivity*ElectricField"
+)
 
-devsim.edge_model(device=device, region=region, name="DField:Potential@n0",
-                  equation="diff(Permittivity*ElectricField, Potential@n0)")
+devsim.edge_model(
+    device=device,
+    region=region,
+    name="DField:Potential@n0",
+    equation="diff(Permittivity*ElectricField, Potential@n0)",
+)
 
-devsim.edge_model(device=device, region=region, name="DField:Potential@n1",
-                  equation="-DField:Potential@n0")
+devsim.edge_model(
+    device=device,
+    region=region,
+    name="DField:Potential@n1",
+    equation="-DField:Potential@n0",
+)
 
 ###
 ### Create the bulk equation
 ###
-devsim.equation(device=device, region=region, name="PotentialEquation", variable_name="Potential",
-                edge_model="DField", variable_update="default")
+devsim.equation(
+    device=device,
+    region=region,
+    name="PotentialEquation",
+    variable_name="Potential",
+    edge_model="DField",
+    variable_update="default",
+)
 
 # the topbias is a circuit node, and we want to prevent it from being overridden by a parameter
 devsim.set_parameter(device=device, region=region, name="botbias", value=0.0)
 
 for name, equation in (
     ("topnode_model", "Potential - topbias"),
-  ("topnode_model:Potential", "1"),
-  ("topnode_model:topbias", "-1"),
-  ("botnode_model", "Potential - botbias"),
-  ("botnode_model:Potential", "1"),
+    ("topnode_model:Potential", "1"),
+    ("topnode_model:topbias", "-1"),
+    ("botnode_model", "Potential - botbias"),
+    ("botnode_model:Potential", "1"),
 ):
     devsim.node_model(device=device, region=region, name=name, equation=equation)
 
 # attached to circuit node
-devsim.contact_equation(device=device, contact="top", name="PotentialEquation",
-                        node_model="topnode_model", edge_charge_model="DField", circuit_node="topbias")
+devsim.contact_equation(
+    device=device,
+    contact="top",
+    name="PotentialEquation",
+    node_model="topnode_model",
+    edge_charge_model="DField",
+    circuit_node="topbias",
+)
 # attached to ground
-devsim.contact_equation(device=device, contact="bot", name="PotentialEquation",
-                        node_model="botnode_model", edge_charge_model="DField")
+devsim.contact_equation(
+    device=device,
+    contact="bot",
+    name="PotentialEquation",
+    node_model="botnode_model",
+    edge_charge_model="DField",
+)
 
 #
 # Voltage source
 #
-devsim.circuit_element(name="V1", n1=1,         n2=0, value=1.0, acreal=1.0)
+devsim.circuit_element(name="V1", n1=1, n2=0, value=1.0, acreal=1.0)
 devsim.circuit_element(name="R1", n1="topbias", n2=1, value=1e3)
 
 #
 devsim.solve(type="dc", absolute_error=1.0, relative_error=1e-10, maximum_iterations=30)
 test_common.print_circuit_solution()
 #
-print(devsim.get_contact_charge(device=device, contact="top", equation="PotentialEquation"))
-print(devsim.get_contact_charge(device=device, contact="bot", equation="PotentialEquation"))
+print(
+    devsim.get_contact_charge(
+        device=device, contact="top", equation="PotentialEquation"
+    )
+)
+print(
+    devsim.get_contact_charge(
+        device=device, contact="bot", equation="PotentialEquation"
+    )
+)
 #
 devsim.solve(type="ac", frequency=1e-3)
 test_common.print_ac_circuit_solution()
@@ -136,7 +194,6 @@ test_common.print_ac_circuit_solution()
 devsim.solve(type="ac", frequency=1e15)
 test_common.print_ac_circuit_solution()
 
-#devsim.element_model(device=device, region=region, name="EDField", equation="DField")
-#for i in devsim.get_element_model_values(device=device, region=region, name="EDField"):
+# devsim.element_model(device=device, region=region, name="EDField", equation="DField")
+# for i in devsim.get_element_model_values(device=device, region=region, name="EDField"):
 #  print(i)
-

--- a/testing/ssac_cap_2d_element.py
+++ b/testing/ssac_cap_2d_element.py
@@ -6,56 +6,68 @@
 import devsim
 import test_common
 
-device="MyDevice"
-region="MyRegion"
+device = "MyDevice"
+region = "MyRegion"
 
-#test_common.CreateSimpleMesh(device, region)
-xmin=-25
-x1  =-24.975
-x2  =-2
-x3  =2
-x4  =24.975
-xmax=25.0
+# test_common.CreateSimpleMesh(device, region)
+xmin = -25
+x1 = -24.975
+x2 = -2
+x3 = 2
+x4 = 24.975
+xmax = 25.0
 
-ymin=0.0
-y1  =0.1
-y2  =0.2
-y3  =0.8
-y4  =0.9
-ymax=50.0
+ymin = 0.0
+y1 = 0.1
+y2 = 0.2
+y3 = 0.8
+y4 = 0.9
+ymax = 50.0
 
 devsim.create_2d_mesh(mesh=device)
 devsim.add_2d_mesh_line(mesh=device, dir="y", pos=ymin, ps=0.1)
-devsim.add_2d_mesh_line(mesh=device, dir="y", pos=y1  , ps=0.1)
-devsim.add_2d_mesh_line(mesh=device, dir="y", pos=y2  , ps=0.1)
-devsim.add_2d_mesh_line(mesh=device, dir="y", pos=y3  , ps=0.1)
-devsim.add_2d_mesh_line(mesh=device, dir="y", pos=y4  , ps=0.1)
+devsim.add_2d_mesh_line(mesh=device, dir="y", pos=y1, ps=0.1)
+devsim.add_2d_mesh_line(mesh=device, dir="y", pos=y2, ps=0.1)
+devsim.add_2d_mesh_line(mesh=device, dir="y", pos=y3, ps=0.1)
+devsim.add_2d_mesh_line(mesh=device, dir="y", pos=y4, ps=0.1)
 devsim.add_2d_mesh_line(mesh=device, dir="y", pos=ymax, ps=5.0)
 
-device=device
-region="air"
+device = device
+region = "air"
 
 devsim.add_2d_mesh_line(mesh=device, dir="x", pos=xmin, ps=5)
-devsim.add_2d_mesh_line(mesh=device, dir="x", pos=x1  , ps=2)
-devsim.add_2d_mesh_line(mesh=device, dir="x", pos=x2  , ps=0.05)
-devsim.add_2d_mesh_line(mesh=device, dir="x", pos=x3  , ps=0.05)
-devsim.add_2d_mesh_line(mesh=device, dir="x", pos=x4  , ps=2)
+devsim.add_2d_mesh_line(mesh=device, dir="x", pos=x1, ps=2)
+devsim.add_2d_mesh_line(mesh=device, dir="x", pos=x2, ps=0.05)
+devsim.add_2d_mesh_line(mesh=device, dir="x", pos=x3, ps=0.05)
+devsim.add_2d_mesh_line(mesh=device, dir="x", pos=x4, ps=2)
 devsim.add_2d_mesh_line(mesh=device, dir="x", pos=xmax, ps=5)
 
-devsim.add_2d_region(mesh=device, material="gas"  , region="air", yl=ymin, yh=ymax, xl=xmin, xh=xmax)
-devsim.add_2d_region(mesh=device, material="metal", region="m1" , yl=y1  , yh=y2  , xl=x1  , xh=x4)
-devsim.add_2d_region(mesh=device, material="metal", region="m2" , yl=y3  , yh=y4  , xl=x2  , xh=x3)
+devsim.add_2d_region(
+    mesh=device, material="gas", region="air", yl=ymin, yh=ymax, xl=xmin, xh=xmax
+)
+devsim.add_2d_region(
+    mesh=device, material="metal", region="m1", yl=y1, yh=y2, xl=x1, xh=x4
+)
+devsim.add_2d_region(
+    mesh=device, material="metal", region="m2", yl=y3, yh=y4, xl=x2, xh=x3
+)
 
 # must be air since contacts don't have any equations
-devsim.add_2d_contact(mesh=device, name="bot", region="air", yl=y1, yh=y2, xl=x1, xh=x4, material="metal")
-devsim.add_2d_contact(mesh=device, name="top", region="air", yl=y3, yh=y4, xl=x2, xh=x3, material="metal")
+devsim.add_2d_contact(
+    mesh=device, name="bot", region="air", yl=y1, yh=y2, xl=x1, xh=x4, material="metal"
+)
+devsim.add_2d_contact(
+    mesh=device, name="top", region="air", yl=y3, yh=y4, xl=x2, xh=x3, material="metal"
+)
 devsim.finalize_mesh(mesh=device)
 devsim.create_device(mesh=device, device=device)
 
 ###
 ### Set parameters on the region
 ###
-devsim.set_parameter(device=device, region=region, name="Permittivity", value=3.9*8.85e-14)
+devsim.set_parameter(
+    device=device, region=region, name="Permittivity", value=3.9 * 8.85e-14
+)
 
 ###
 ### Create the Potential solution variable
@@ -71,66 +83,113 @@ devsim.edge_from_node_model(device=device, region=region, node_model="Potential"
 ### Electric field on each edge, as well as its derivatives with respect to
 ### the potential at each node
 ###
-devsim.edge_model(device=device, region=region, name="ElectricField",
-                  equation="(Potential@n0 - Potential@n1)*EdgeInverseLength")
+devsim.edge_model(
+    device=device,
+    region=region,
+    name="ElectricField",
+    equation="(Potential@n0 - Potential@n1)*EdgeInverseLength",
+)
 
-devsim.edge_model(device=device, region=region, name="ElectricField:Potential@n0",
-                  equation="EdgeInverseLength")
+devsim.edge_model(
+    device=device,
+    region=region,
+    name="ElectricField:Potential@n0",
+    equation="EdgeInverseLength",
+)
 
-devsim.edge_model(device=device, region=region, name="ElectricField:Potential@n1",
-                  equation="-EdgeInverseLength")
+devsim.edge_model(
+    device=device,
+    region=region,
+    name="ElectricField:Potential@n1",
+    equation="-EdgeInverseLength",
+)
 
 ###
 ### Model the D Field
 ###
-devsim.element_model(device=device, region=region, name="DField",
-                  equation="Permittivity*ElectricField")
+devsim.element_model(
+    device=device, region=region, name="DField", equation="Permittivity*ElectricField"
+)
 
-devsim.element_model(device=device, region=region, name="DField:Potential@en0",
-                  equation="diff(Permittivity*ElectricField, Potential@n0)")
+devsim.element_model(
+    device=device,
+    region=region,
+    name="DField:Potential@en0",
+    equation="diff(Permittivity*ElectricField, Potential@n0)",
+)
 
-devsim.element_model(device=device, region=region, name="DField:Potential@en1",
-                  equation="-DField:Potential@en0")
+devsim.element_model(
+    device=device,
+    region=region,
+    name="DField:Potential@en1",
+    equation="-DField:Potential@en0",
+)
 
-devsim.element_model(device=device, region=region, name="DField:Potential@en2",
-                  equation="0")
+devsim.element_model(
+    device=device, region=region, name="DField:Potential@en2", equation="0"
+)
 
 ###
 ### Create the bulk equation
 ###
-devsim.equation(device=device, region=region, name="PotentialEquation", variable_name="Potential",
-                element_model="DField", variable_update="default")
+devsim.equation(
+    device=device,
+    region=region,
+    name="PotentialEquation",
+    variable_name="Potential",
+    element_model="DField",
+    variable_update="default",
+)
 
 # the topbias is a circuit node, and we want to prevent it from being overridden by a parameter
 devsim.set_parameter(device=device, region=region, name="botbias", value=0.0)
 
 for name, equation in (
     ("topnode_model", "Potential - topbias"),
-  ("topnode_model:Potential", "1"),
-  ("topnode_model:topbias", "-1"),
-  ("botnode_model", "Potential - botbias"),
-  ("botnode_model:Potential", "1"),
+    ("topnode_model:Potential", "1"),
+    ("topnode_model:topbias", "-1"),
+    ("botnode_model", "Potential - botbias"),
+    ("botnode_model:Potential", "1"),
 ):
     devsim.node_model(device=device, region=region, name=name, equation=equation)
 
 # attached to circuit node
-devsim.contact_equation(device=device, contact="top", name="PotentialEquation",
-                        node_model="topnode_model", element_charge_model="DField", circuit_node="topbias")
+devsim.contact_equation(
+    device=device,
+    contact="top",
+    name="PotentialEquation",
+    node_model="topnode_model",
+    element_charge_model="DField",
+    circuit_node="topbias",
+)
 # attached to ground
-devsim.contact_equation(device=device, contact="bot", name="PotentialEquation",
-                        node_model="botnode_model", element_charge_model="DField")
+devsim.contact_equation(
+    device=device,
+    contact="bot",
+    name="PotentialEquation",
+    node_model="botnode_model",
+    element_charge_model="DField",
+)
 
 #
 # Voltage source
 #
-devsim.circuit_element(name="V1", n1=1,         n2=0, value=1.0, acreal=1.0)
+devsim.circuit_element(name="V1", n1=1, n2=0, value=1.0, acreal=1.0)
 devsim.circuit_element(name="R1", n1="topbias", n2=1, value=1e3)
 
 #
 devsim.solve(type="dc", absolute_error=1.0, relative_error=1e-10, maximum_iterations=30)
 #
-print(devsim.get_contact_charge(device=device, contact="top", equation="PotentialEquation"))
-print(devsim.get_contact_charge(device=device, contact="bot", equation="PotentialEquation"))
+print(
+    devsim.get_contact_charge(
+        device=device, contact="top", equation="PotentialEquation"
+    )
+)
+print(
+    devsim.get_contact_charge(
+        device=device, contact="bot", equation="PotentialEquation"
+    )
+)
 #
 devsim.solve(type="ac", frequency=1e-3)
 test_common.print_ac_circuit_solution()
@@ -139,17 +198,17 @@ test_common.print_ac_circuit_solution()
 devsim.solve(type="ac", frequency=1e15)
 test_common.print_ac_circuit_solution()
 
-#for i in devsim.get_element_model_values(device=device, region=region, name="DField"):
+# for i in devsim.get_element_model_values(device=device, region=region, name="DField"):
 #  print(i)
 #
-#ec = devsim.get_edge_model_values(device=device, region=region, name="EdgeCouple")
-#devsim.element_model(device=device, region=region, name="eindex", equation="edge_index")
-#ei = [int(x) for x in devsim.get_element_model_values(device=device, region=region, name="eindex")]
-#eec = devsim.get_element_model_values(device=device, region=region, name="ElementEdgeCouple")
-#ec_compare=[0.0]*len(ec)
-#for q, v in zip(ei, eec):
+# ec = devsim.get_edge_model_values(device=device, region=region, name="EdgeCouple")
+# devsim.element_model(device=device, region=region, name="eindex", equation="edge_index")
+# ei = [int(x) for x in devsim.get_element_model_values(device=device, region=region, name="eindex")]
+# eec = devsim.get_element_model_values(device=device, region=region, name="ElementEdgeCouple")
+# ec_compare=[0.0]*len(ec)
+# for q, v in zip(ei, eec):
 #  #print(q,v)
 #  ec_compare[q] += v
 #
-#for q,v in zip(ec, ec_compare):
+# for q,v in zip(ec, ec_compare):
 #  print(q,v)

--- a/testing/ssac_cap_3d_edge.py
+++ b/testing/ssac_cap_3d_edge.py
@@ -6,15 +6,17 @@
 import devsim
 import test_common
 
-device="test"
-region="bulk"
-devsim.load_devices(file='3dtetmesh.msh')
-#c=3.9*8.85e-14*(6e-2*6e-2)/6e-2
+device = "test"
+region = "bulk"
+devsim.load_devices(file="3dtetmesh.msh")
+# c=3.9*8.85e-14*(6e-2*6e-2)/6e-2
 
 ###
 ### Set parameters on the region
 ###
-devsim.set_parameter(device=device, region=region, name="Permittivity", value=3.9*8.85e-14)
+devsim.set_parameter(
+    device=device, region=region, name="Permittivity", value=3.9 * 8.85e-14
+)
 
 ###
 ### Create the Potential solution variable
@@ -30,63 +32,109 @@ devsim.edge_from_node_model(device=device, region=region, node_model="Potential"
 ### Electric field on each edge, as well as its derivatives with respect to
 ### the potential at each node
 ###
-devsim.edge_model(device=device, region=region, name="ElectricField",
-                  equation="(Potential@n0 - Potential@n1)*EdgeInverseLength")
+devsim.edge_model(
+    device=device,
+    region=region,
+    name="ElectricField",
+    equation="(Potential@n0 - Potential@n1)*EdgeInverseLength",
+)
 
-devsim.edge_model(device=device, region=region, name="ElectricField:Potential@n0",
-                  equation="EdgeInverseLength")
+devsim.edge_model(
+    device=device,
+    region=region,
+    name="ElectricField:Potential@n0",
+    equation="EdgeInverseLength",
+)
 
-devsim.edge_model(device=device, region=region, name="ElectricField:Potential@n1",
-                  equation="-EdgeInverseLength")
+devsim.edge_model(
+    device=device,
+    region=region,
+    name="ElectricField:Potential@n1",
+    equation="-EdgeInverseLength",
+)
 
 ###
 ### Model the D Field
 ###
-devsim.edge_model(device=device, region=region, name="DField",
-                  equation="Permittivity*ElectricField")
+devsim.edge_model(
+    device=device, region=region, name="DField", equation="Permittivity*ElectricField"
+)
 
-devsim.edge_model(device=device, region=region, name="DField:Potential@n0",
-                  equation="diff(Permittivity*ElectricField, Potential@n0)")
+devsim.edge_model(
+    device=device,
+    region=region,
+    name="DField:Potential@n0",
+    equation="diff(Permittivity*ElectricField, Potential@n0)",
+)
 
-devsim.edge_model(device=device, region=region, name="DField:Potential@n1",
-                  equation="-DField:Potential@n0")
+devsim.edge_model(
+    device=device,
+    region=region,
+    name="DField:Potential@n1",
+    equation="-DField:Potential@n0",
+)
 
 ###
 ### Create the bulk equation
 ###
-devsim.equation(device=device, region=region, name="PotentialEquation", variable_name="Potential",
-                edge_model="DField", variable_update="default")
+devsim.equation(
+    device=device,
+    region=region,
+    name="PotentialEquation",
+    variable_name="Potential",
+    edge_model="DField",
+    variable_update="default",
+)
 
 # the topbias is a circuit node, and we want to prevent it from being overridden by a parameter
 devsim.set_parameter(device=device, region=region, name="botbias", value=0.0)
 
 for name, equation in (
     ("topnode_model", "Potential - topbias"),
-  ("topnode_model:Potential", "1"),
-  ("topnode_model:topbias", "-1"),
-  ("botnode_model", "Potential - botbias"),
-  ("botnode_model:Potential", "1"),
+    ("topnode_model:Potential", "1"),
+    ("topnode_model:topbias", "-1"),
+    ("botnode_model", "Potential - botbias"),
+    ("botnode_model:Potential", "1"),
 ):
     devsim.node_model(device=device, region=region, name=name, equation=equation)
 
 # attached to circuit node
-devsim.contact_equation(device=device, contact="top", name="PotentialEquation",
-                        node_model="topnode_model", edge_charge_model="DField", circuit_node="topbias")
+devsim.contact_equation(
+    device=device,
+    contact="top",
+    name="PotentialEquation",
+    node_model="topnode_model",
+    edge_charge_model="DField",
+    circuit_node="topbias",
+)
 # attached to ground
-devsim.contact_equation(device=device, contact="bot", name="PotentialEquation",
-                        node_model="botnode_model", edge_charge_model="DField")
+devsim.contact_equation(
+    device=device,
+    contact="bot",
+    name="PotentialEquation",
+    node_model="botnode_model",
+    edge_charge_model="DField",
+)
 
 #
 # Voltage source
 #
-devsim.circuit_element(name="V1", n1=1,         n2=0, value=1.0, acreal=1.0)
+devsim.circuit_element(name="V1", n1=1, n2=0, value=1.0, acreal=1.0)
 devsim.circuit_element(name="R1", n1="topbias", n2=1, value=1e3)
 
 #
 devsim.solve(type="dc", absolute_error=1.0, relative_error=1e-10, maximum_iterations=30)
 #
-print(devsim.get_contact_charge(device=device, contact="top", equation="PotentialEquation"))
-print(devsim.get_contact_charge(device=device, contact="bot", equation="PotentialEquation"))
+print(
+    devsim.get_contact_charge(
+        device=device, contact="top", equation="PotentialEquation"
+    )
+)
+print(
+    devsim.get_contact_charge(
+        device=device, contact="bot", equation="PotentialEquation"
+    )
+)
 #
 devsim.solve(type="ac", frequency=1e-3)
 test_common.print_ac_circuit_solution()
@@ -95,7 +143,6 @@ test_common.print_ac_circuit_solution()
 devsim.solve(type="ac", frequency=1e15)
 test_common.print_ac_circuit_solution()
 
-#devsim.element_model(device=device, region=region, name="EDField", equation="DField")
-#for i in devsim.get_element_model_values(device=device, region=region, name="EDField"):
+# devsim.element_model(device=device, region=region, name="EDField", equation="DField")
+# for i in devsim.get_element_model_values(device=device, region=region, name="EDField"):
 #  print(i)
-

--- a/testing/ssac_cap_3d_element.py
+++ b/testing/ssac_cap_3d_element.py
@@ -6,15 +6,17 @@
 import devsim
 import test_common
 
-device="test"
-region="bulk"
-devsim.load_devices(file='3dtetmesh.msh')
-#c=3.9*8.85e-14*(6e-2*6e-2)/6e-2
+device = "test"
+region = "bulk"
+devsim.load_devices(file="3dtetmesh.msh")
+# c=3.9*8.85e-14*(6e-2*6e-2)/6e-2
 
 ###
 ### Set parameters on the region
 ###
-devsim.set_parameter(device=device, region=region, name="Permittivity", value=3.9*8.85e-14)
+devsim.set_parameter(
+    device=device, region=region, name="Permittivity", value=3.9 * 8.85e-14
+)
 
 ###
 ### Create the Potential solution variable
@@ -30,69 +32,117 @@ devsim.edge_from_node_model(device=device, region=region, node_model="Potential"
 ### Electric field on each edge, as well as its derivatives with respect to
 ### the potential at each node
 ###
-devsim.edge_model(device=device, region=region, name="ElectricField",
-                  equation="(Potential@n0 - Potential@n1)*EdgeInverseLength")
+devsim.edge_model(
+    device=device,
+    region=region,
+    name="ElectricField",
+    equation="(Potential@n0 - Potential@n1)*EdgeInverseLength",
+)
 
-devsim.edge_model(device=device, region=region, name="ElectricField:Potential@n0",
-                  equation="EdgeInverseLength")
+devsim.edge_model(
+    device=device,
+    region=region,
+    name="ElectricField:Potential@n0",
+    equation="EdgeInverseLength",
+)
 
-devsim.edge_model(device=device, region=region, name="ElectricField:Potential@n1",
-                  equation="-EdgeInverseLength")
+devsim.edge_model(
+    device=device,
+    region=region,
+    name="ElectricField:Potential@n1",
+    equation="-EdgeInverseLength",
+)
 
 ###
 ### Model the D Field
 ###
-devsim.element_model(device=device, region=region, name="DField",
-                  equation="Permittivity*ElectricField")
+devsim.element_model(
+    device=device, region=region, name="DField", equation="Permittivity*ElectricField"
+)
 
-devsim.element_model(device=device, region=region, name="DField:Potential@en0",
-                  equation="diff(Permittivity*ElectricField, Potential@n0)")
+devsim.element_model(
+    device=device,
+    region=region,
+    name="DField:Potential@en0",
+    equation="diff(Permittivity*ElectricField, Potential@n0)",
+)
 
-devsim.element_model(device=device, region=region, name="DField:Potential@en1",
-                  equation="-DField:Potential@en0")
+devsim.element_model(
+    device=device,
+    region=region,
+    name="DField:Potential@en1",
+    equation="-DField:Potential@en0",
+)
 
-devsim.element_model(device=device, region=region, name="DField:Potential@en2",
-                  equation="0")
+devsim.element_model(
+    device=device, region=region, name="DField:Potential@en2", equation="0"
+)
 
-devsim.element_model(device=device, region=region, name="DField:Potential@en3",
-                  equation="0")
+devsim.element_model(
+    device=device, region=region, name="DField:Potential@en3", equation="0"
+)
 
 ###
 ### Create the bulk equation
 ###
-devsim.equation(device=device, region=region, name="PotentialEquation", variable_name="Potential",
-                element_model="DField", variable_update="default")
+devsim.equation(
+    device=device,
+    region=region,
+    name="PotentialEquation",
+    variable_name="Potential",
+    element_model="DField",
+    variable_update="default",
+)
 
 # the topbias is a circuit node, and we want to prevent it from being overridden by a parameter
 devsim.set_parameter(device=device, region=region, name="botbias", value=0.0)
 
 for name, equation in (
     ("topnode_model", "Potential - topbias"),
-  ("topnode_model:Potential", "1"),
-  ("topnode_model:topbias", "-1"),
-  ("botnode_model", "Potential - botbias"),
-  ("botnode_model:Potential", "1"),
+    ("topnode_model:Potential", "1"),
+    ("topnode_model:topbias", "-1"),
+    ("botnode_model", "Potential - botbias"),
+    ("botnode_model:Potential", "1"),
 ):
     devsim.node_model(device=device, region=region, name=name, equation=equation)
 
 # attached to circuit node
-devsim.contact_equation(device=device, contact="top", name="PotentialEquation",
-                        node_model="topnode_model", element_charge_model="DField", circuit_node="topbias")
+devsim.contact_equation(
+    device=device,
+    contact="top",
+    name="PotentialEquation",
+    node_model="topnode_model",
+    element_charge_model="DField",
+    circuit_node="topbias",
+)
 # attached to ground
-devsim.contact_equation(device=device, contact="bot", name="PotentialEquation",
-                        node_model="botnode_model", element_charge_model="DField")
+devsim.contact_equation(
+    device=device,
+    contact="bot",
+    name="PotentialEquation",
+    node_model="botnode_model",
+    element_charge_model="DField",
+)
 
 #
 # Voltage source
 #
-devsim.circuit_element(name="V1", n1=1,         n2=0, value=1.0, acreal=1.0)
+devsim.circuit_element(name="V1", n1=1, n2=0, value=1.0, acreal=1.0)
 devsim.circuit_element(name="R1", n1="topbias", n2=1, value=1e3)
 
 #
 devsim.solve(type="dc", absolute_error=1.0, relative_error=1e-10, maximum_iterations=30)
 #
-print(devsim.get_contact_charge(device=device, contact="top", equation="PotentialEquation"))
-print(devsim.get_contact_charge(device=device, contact="bot", equation="PotentialEquation"))
+print(
+    devsim.get_contact_charge(
+        device=device, contact="top", equation="PotentialEquation"
+    )
+)
+print(
+    devsim.get_contact_charge(
+        device=device, contact="bot", equation="PotentialEquation"
+    )
+)
 #
 devsim.solve(type="ac", frequency=1e-3)
 test_common.print_ac_circuit_solution()
@@ -101,17 +151,17 @@ test_common.print_ac_circuit_solution()
 devsim.solve(type="ac", frequency=1e15)
 test_common.print_ac_circuit_solution()
 
-#for i in devsim.get_element_model_values(device=device, region=region, name="DField"):
+# for i in devsim.get_element_model_values(device=device, region=region, name="DField"):
 #  print(i)
 #
-#ec = devsim.get_edge_model_values(device=device, region=region, name="EdgeCouple")
-#devsim.element_model(device=device, region=region, name="eindex", equation="edge_index")
-#ei = [int(x) for x in devsim.get_element_model_values(device=device, region=region, name="eindex")]
-#eec = devsim.get_element_model_values(device=device, region=region, name="ElementEdgeCouple")
-#ec_compare=[0.0]*len(ec)
-#for q, v in zip(ei, eec):
+# ec = devsim.get_edge_model_values(device=device, region=region, name="EdgeCouple")
+# devsim.element_model(device=device, region=region, name="eindex", equation="edge_index")
+# ei = [int(x) for x in devsim.get_element_model_values(device=device, region=region, name="eindex")]
+# eec = devsim.get_element_model_values(device=device, region=region, name="ElementEdgeCouple")
+# ec_compare=[0.0]*len(ec)
+# for q, v in zip(ei, eec):
 #  #print(q,v)
 #  ec_compare[q] += v
 #
-#for q,v in zip(ec, ec_compare):
+# for q,v in zip(ec, ec_compare):
 #  print(q,v)

--- a/testing/ssac_circ.py
+++ b/testing/ssac_circ.py
@@ -16,4 +16,3 @@ devsim.solve(type="ac", frequency=1.0e2)
 test_common.print_ac_circuit_solution()
 devsim.solve(type="ac", frequency=1.0e3)
 test_common.print_ac_circuit_solution()
-

--- a/testing/ssac_res.py
+++ b/testing/ssac_res.py
@@ -14,7 +14,9 @@ res1.run_initial_bias(use_circuit_bias=True)
 
 for v in (0.0, 0.01, 0.02, 0.03, 0.04, 0.05, 0.06, 0.07, 0.08, 0.09, 0.10):
     devsim.circuit_alter(name="V1", value=v)
-    devsim.solve(type="dc", absolute_error=1.0, relative_error=1e-10, maximum_iterations=30)
+    devsim.solve(
+        type="dc", absolute_error=1.0, relative_error=1e-10, maximum_iterations=30
+    )
     for contact in res1.contacts:
         test_common.printResistorCurrent(device=res1.device, contact=contact)
 
@@ -24,6 +26,5 @@ for f in (0, 1, 1e2, 1e3, 1e4, 1e5, 1e6, 1e7, 1e8, 1e9, 1e10, 1e11, 1e12):
 
 for x in devsim.get_circuit_node_list():
     for y in devsim.get_circuit_solution_list():
-        z=devsim.get_circuit_node_value(node=x, solution=y)
-        print("%s %s %1.15e" % (x,y,z))
-
+        z = devsim.get_circuit_node_value(node=x, solution=y)
+        print("%s %s %1.15e" % (x, y, z))

--- a/testing/symdiff1.py
+++ b/testing/symdiff1.py
@@ -4,10 +4,11 @@
 
 import devsim
 
+
 def callSymdiff(arg):
-    x  = devsim.symdiff(expr=arg)
+    x = devsim.symdiff(expr=arg)
     dx = devsim.symdiff(expr="diff(%s,x)" % arg)
-    print ('"%s"\n"%s"\n"%s"\n' % (arg, x, dx))
+    print('"%s"\n"%s"\n"%s"\n' % (arg, x, dx))
 
 
 callSymdiff("min(x*b, x+b)")

--- a/testing/test_common.py
+++ b/testing/test_common.py
@@ -4,180 +4,234 @@
 
 import devsim
 
+
 def print_ac_circuit_solution():
-    print('Circuit AC Solution')
-    nodes = devsim.get_circuit_node_list()
+    print("Circuit AC Solution")
+    _nodes = devsim.get_circuit_node_list()
     for node in devsim.get_circuit_node_list():
-        r = devsim.get_circuit_node_value(solution='ssac_real', node=node)
-        i = devsim.get_circuit_node_value(solution='ssac_imag', node=node)
-        print("%s\t%1.15e\t%1.15e" % (node, r , i))
+        r = devsim.get_circuit_node_value(solution="ssac_real", node=node)
+        i = devsim.get_circuit_node_value(solution="ssac_imag", node=node)
+        print("%s\t%1.15e\t%1.15e" % (node, r, i))
+
 
 def print_circuit_solution():
-    print('Circuit Solution')
-    nodes = devsim.get_circuit_node_list()
+    print("Circuit Solution")
+    _nodes = devsim.get_circuit_node_list()
     for node in devsim.get_circuit_node_list():
-        r = devsim.get_circuit_node_value(solution='dcop', node=node)
+        r = devsim.get_circuit_node_value(solution="dcop", node=node)
         print("%s\t%1.15e" % (node, r))
 
 
 def printResistorCurrent(device, contact):
-    ecurr=devsim.get_contact_current(device=device, contact=contact, equation="ElectronContinuityEquation")
-    hcurr=0.0
-    tcurr=ecurr + hcurr
-    print("Contact: %s\nElectron %g\nHole %g\nTotal %g" % (contact, ecurr, hcurr, tcurr))
+    ecurr = devsim.get_contact_current(
+        device=device, contact=contact, equation="ElectronContinuityEquation"
+    )
+    hcurr = 0.0
+    tcurr = ecurr + hcurr
+    print(
+        "Contact: %s\nElectron %g\nHole %g\nTotal %g" % (contact, ecurr, hcurr, tcurr)
+    )
+
 
 ####
 #### Meshing
 ####
-def CreateSimpleMesh(device, region, material='Si'):
-    '''
-      Commonly used for the regressions
-      device length: 1
-      spacing:       0.1
-      contacts:      top (x=0), bot (x=1)
-    '''
-    devsim.create_1d_mesh  (mesh='dog')
-    devsim.add_1d_mesh_line(mesh='dog', pos=0, ps=0.1, tag='top')
-    devsim.add_1d_mesh_line(mesh='dog', pos=1, ps=0.1, tag='bot')
-    devsim.add_1d_contact  (mesh='dog', name='top', tag='top', material='metal')
-    devsim.add_1d_contact  (mesh='dog', name='bot', tag='bot', material='metal')
-    devsim.add_1d_region   (mesh='dog', material=material, region=region, tag1='top', tag2='bot')
-    devsim.finalize_mesh   (mesh='dog')
-    devsim.create_device   (mesh='dog', device=device)
+def CreateSimpleMesh(device, region, material="Si"):
+    """
+    Commonly used for the regressions
+    device length: 1
+    spacing:       0.1
+    contacts:      top (x=0), bot (x=1)
+    """
+    devsim.create_1d_mesh(mesh="dog")
+    devsim.add_1d_mesh_line(mesh="dog", pos=0, ps=0.1, tag="top")
+    devsim.add_1d_mesh_line(mesh="dog", pos=1, ps=0.1, tag="bot")
+    devsim.add_1d_contact(mesh="dog", name="top", tag="top", material="metal")
+    devsim.add_1d_contact(mesh="dog", name="bot", tag="bot", material="metal")
+    devsim.add_1d_region(
+        mesh="dog", material=material, region=region, tag1="top", tag2="bot"
+    )
+    devsim.finalize_mesh(mesh="dog")
+    devsim.create_device(mesh="dog", device=device)
 
-def CreateSimpleMeshWithInterface(device, region0, region1, interface, material1='Si', material2='Si'):
-    '''
-      Commonly used for the regressions
-      device length: 1
-      spacing:       0.1
-      contacts:      top (x=0), bot (x=1)
-      interface:     mid (x=0.5)
-    '''
-    devsim.create_1d_mesh  (mesh='dog')
-    devsim.add_1d_mesh_line(mesh='dog', pos=0, ps=0.1, tag='top')
-    devsim.add_1d_mesh_line(mesh='dog', pos=0.5, ps=0.1, tag='mid')
-    devsim.add_1d_mesh_line(mesh='dog', pos=1, ps=0.1, tag='bot')
-    devsim.add_1d_contact  (mesh='dog', name='top', tag='top', material='metal')
-    devsim.add_1d_contact  (mesh='dog', name='bot', tag='bot', material='metal')
-    devsim.add_1d_interface(mesh='dog', name=interface, tag='mid')
-    devsim.add_1d_region(mesh='dog', material=material1, region=region0, tag1='top', tag2='mid')
-    devsim.add_1d_region(mesh='dog', material=material2, region=region1, tag1='mid', tag2='bot')
-    devsim.finalize_mesh   (mesh='dog')
-    devsim.create_device   (mesh='dog', device=device)
 
-def CreateNoiseMesh(device, region, material='Si'):
-    '''
-      Commonly used for the regressions
-      device length: 1
-      spacing:       0.1
-      contacts:      top (x=0), bot (x=1)
-    '''
-    devsim.create_1d_mesh  (mesh='dog')
-    devsim.add_1d_mesh_line(mesh='dog', pos=0, ps=5e-7, tag='top')
-    devsim.add_1d_mesh_line(mesh='dog', pos=1e-5, ps=5e-7, tag='bot')
-    devsim.add_1d_contact  (mesh='dog', name='top', tag='top', material='metal')
-    devsim.add_1d_contact  (mesh='dog', name='bot', tag='bot', material='metal')
-    devsim.add_1d_region   (mesh='dog', material=material, region=region, tag1='top', tag2='bot')
-    devsim.finalize_mesh   (mesh='dog')
-    devsim.create_device   (mesh='dog', device=device)
+def CreateSimpleMeshWithInterface(
+    device, region0, region1, interface, material1="Si", material2="Si"
+):
+    """
+    Commonly used for the regressions
+    device length: 1
+    spacing:       0.1
+    contacts:      top (x=0), bot (x=1)
+    interface:     mid (x=0.5)
+    """
+    devsim.create_1d_mesh(mesh="dog")
+    devsim.add_1d_mesh_line(mesh="dog", pos=0, ps=0.1, tag="top")
+    devsim.add_1d_mesh_line(mesh="dog", pos=0.5, ps=0.1, tag="mid")
+    devsim.add_1d_mesh_line(mesh="dog", pos=1, ps=0.1, tag="bot")
+    devsim.add_1d_contact(mesh="dog", name="top", tag="top", material="metal")
+    devsim.add_1d_contact(mesh="dog", name="bot", tag="bot", material="metal")
+    devsim.add_1d_interface(mesh="dog", name=interface, tag="mid")
+    devsim.add_1d_region(
+        mesh="dog", material=material1, region=region0, tag1="top", tag2="mid"
+    )
+    devsim.add_1d_region(
+        mesh="dog", material=material2, region=region1, tag1="mid", tag2="bot"
+    )
+    devsim.finalize_mesh(mesh="dog")
+    devsim.create_device(mesh="dog", device=device)
+
+
+def CreateNoiseMesh(device, region, material="Si"):
+    """
+    Commonly used for the regressions
+    device length: 1
+    spacing:       0.1
+    contacts:      top (x=0), bot (x=1)
+    """
+    devsim.create_1d_mesh(mesh="dog")
+    devsim.add_1d_mesh_line(mesh="dog", pos=0, ps=5e-7, tag="top")
+    devsim.add_1d_mesh_line(mesh="dog", pos=1e-5, ps=5e-7, tag="bot")
+    devsim.add_1d_contact(mesh="dog", name="top", tag="top", material="metal")
+    devsim.add_1d_contact(mesh="dog", name="bot", tag="bot", material="metal")
+    devsim.add_1d_region(
+        mesh="dog", material=material, region=region, tag1="top", tag2="bot"
+    )
+    devsim.finalize_mesh(mesh="dog")
+    devsim.create_device(mesh="dog", device=device)
+
 
 ####
 #### Constants
 ####
 def SetupResistorConstants(device, region):
     for name, value in (
-        ("Permittivity",     11.1*8.85e-14),
-      ("ElectronCharge",   1.6e-19),
-      ("IntrinsicDensity", 1.0e10),
-      ("ThermalVoltage",   0.0259),
-      ("mu_n", 400),
-      ("mu_p", 200),
+        ("Permittivity", 11.1 * 8.85e-14),
+        ("ElectronCharge", 1.6e-19),
+        ("IntrinsicDensity", 1.0e10),
+        ("ThermalVoltage", 0.0259),
+        ("mu_n", 400),
+        ("mu_p", 200),
     ):
         devsim.set_parameter(device=device, region=region, name=name, value=value)
 
+
 def SetupInitialResistorSystem(device, region, net_doping=1e16):
-    '''
-      resistor physics
-    '''
-    devsim.set_parameter(device=device, region=region, name='net_doping', value=net_doping)
-    devsim.node_solution(device=device, region=region, name='Potential')
-    devsim.edge_from_node_model(device=device, region=region, node_model='Potential')
+    """
+    resistor physics
+    """
+    devsim.set_parameter(
+        device=device, region=region, name="net_doping", value=net_doping
+    )
+    devsim.node_solution(device=device, region=region, name="Potential")
+    devsim.edge_from_node_model(device=device, region=region, node_model="Potential")
 
     # node models
     for name, equation in (
-        ("NetDoping",                 "net_doping"),
-      ("IntrinsicElectrons",        "NetDoping"),
-      ("IntrinsicCharge",           "-IntrinsicElectrons + NetDoping"),
-      ("IntrinsicCharge:Potential", "-IntrinsicElectrons:Potential"),
+        ("NetDoping", "net_doping"),
+        ("IntrinsicElectrons", "NetDoping"),
+        ("IntrinsicCharge", "-IntrinsicElectrons + NetDoping"),
+        ("IntrinsicCharge:Potential", "-IntrinsicElectrons:Potential"),
     ):
         devsim.node_model(device=device, region=region, name=name, equation=equation)
 
     # edge models
     for name, equation in (
-        ("ElectricField",              "(Potential@n0 - Potential@n1)*EdgeInverseLength"),
-      ("ElectricField:Potential@n0", "EdgeInverseLength"),
-      ("ElectricField:Potential@n1", "-EdgeInverseLength"),
-      ("PotentialEdgeFlux",              "Permittivity*ElectricField"),
-      ("PotentialEdgeFlux:Potential@n0", "diff(Permittivity*ElectricField, Potential@n0)"),
-      ("PotentialEdgeFlux:Potential@n1", "-PotentialEdgeFlux:Potential@n0"),
+        ("ElectricField", "(Potential@n0 - Potential@n1)*EdgeInverseLength"),
+        ("ElectricField:Potential@n0", "EdgeInverseLength"),
+        ("ElectricField:Potential@n1", "-EdgeInverseLength"),
+        ("PotentialEdgeFlux", "Permittivity*ElectricField"),
+        (
+            "PotentialEdgeFlux:Potential@n0",
+            "diff(Permittivity*ElectricField, Potential@n0)",
+        ),
+        ("PotentialEdgeFlux:Potential@n1", "-PotentialEdgeFlux:Potential@n0"),
     ):
         devsim.edge_model(device=device, region=region, name=name, equation=equation)
 
     ####
     #### PotentialEquation
     ####
-    devsim.equation(device=device, region=region, name="PotentialEquation", variable_name="Potential", edge_model="PotentialEdgeFlux", variable_update="log_damp")
+    devsim.equation(
+        device=device,
+        region=region,
+        name="PotentialEquation",
+        variable_name="Potential",
+        edge_model="PotentialEdgeFlux",
+        variable_update="log_damp",
+    )
+
 
 def SetupCarrierResistorSystem(device, region):
-    '''
-      This adds electron continuity
-    '''
-    devsim.node_solution(device=device, region=region, name='Electrons')
-    devsim.edge_from_node_model(device=device, region=region, node_model='Electrons')
-    devsim.set_node_values(device=device, region=region, name='Electrons', init_from='IntrinsicElectrons')
+    """
+    This adds electron continuity
+    """
+    devsim.node_solution(device=device, region=region, name="Electrons")
+    devsim.edge_from_node_model(device=device, region=region, node_model="Electrons")
+    devsim.set_node_values(
+        device=device, region=region, name="Electrons", init_from="IntrinsicElectrons"
+    )
 
     ####
     #### PotentialNodeCharge
     ####
     for name, equation in (
-        ("PotentialNodeCharge",           "-ElectronCharge*(-Electrons + NetDoping)"),
-      ("PotentialNodeCharge:Electrons", "+ElectronCharge"),
+        ("PotentialNodeCharge", "-ElectronCharge*(-Electrons + NetDoping)"),
+        ("PotentialNodeCharge:Electrons", "+ElectronCharge"),
     ):
         devsim.node_model(device=device, region=region, name=name, equation=equation)
 
     ####
     #### PotentialEquation modified for carriers present
     ####
-    devsim.equation(device=device, region=region, name='PotentialEquation', variable_name='Potential', node_model='PotentialNodeCharge',
-                    edge_model="PotentialEdgeFlux", variable_update="default")
-
+    devsim.equation(
+        device=device,
+        region=region,
+        name="PotentialEquation",
+        variable_name="Potential",
+        node_model="PotentialNodeCharge",
+        edge_model="PotentialEdgeFlux",
+        variable_update="default",
+    )
 
     ####
     #### vdiff, Bern01, Bern10
     ####
     for name, equation in (
-        ("vdiff",               "(Potential@n0 - Potential@n1)/ThermalVoltage"),
-      ("vdiff:Potential@n0",  "ThermalVoltage^(-1)"),
-      ("vdiff:Potential@n1",  "-ThermalVoltage^(-1)"),
-      ("Bern01",              "B(vdiff)"),
-      ("Bern01:Potential@n0", "dBdx(vdiff)*vdiff:Potential@n0"),
-      ("Bern01:Potential@n1", "dBdx(vdiff)*vdiff:Potential@n1"),
-      ("Bern10",              "Bern01 + vdiff"),
-      ("Bern10:Potential@n0", "Bern01:Potential@n0 + vdiff:Potential@n0"),
-      ("Bern10:Potential@n1", "Bern01:Potential@n1 + vdiff:Potential@n1"),
+        ("vdiff", "(Potential@n0 - Potential@n1)/ThermalVoltage"),
+        ("vdiff:Potential@n0", "ThermalVoltage^(-1)"),
+        ("vdiff:Potential@n1", "-ThermalVoltage^(-1)"),
+        ("Bern01", "B(vdiff)"),
+        ("Bern01:Potential@n0", "dBdx(vdiff)*vdiff:Potential@n0"),
+        ("Bern01:Potential@n1", "dBdx(vdiff)*vdiff:Potential@n1"),
+        ("Bern10", "Bern01 + vdiff"),
+        ("Bern10:Potential@n0", "Bern01:Potential@n0 + vdiff:Potential@n0"),
+        ("Bern10:Potential@n1", "Bern01:Potential@n1 + vdiff:Potential@n1"),
     ):
         devsim.edge_model(device=device, region=region, name=name, equation=equation)
 
     ####
     #### Electron Current
     ####
-    current_equation="ElectronCharge*mu_n*EdgeInverseLength*ThermalVoltage*(Electrons@n1*Bern10 - Electrons@n0*Bern01)"
+    current_equation = "ElectronCharge*mu_n*EdgeInverseLength*ThermalVoltage*(Electrons@n1*Bern10 - Electrons@n0*Bern01)"
     for name, equation in (
         ("ElectronCurrent", current_equation),
-      ("ElectronCurrent:Electrons@n0", "simplify(diff(%s, Electrons@n0))" % current_equation),
-      ("ElectronCurrent:Electrons@n1", "simplify(diff(%s, Electrons@n1))" % current_equation),
-      ("ElectronCurrent:Potential@n0", "simplify(diff(%s, Potential@n0))" % current_equation),
-      ("ElectronCurrent:Potential@n1", "simplify(diff(%s, Potential@n1))" % current_equation),
+        (
+            "ElectronCurrent:Electrons@n0",
+            "simplify(diff(%s, Electrons@n0))" % current_equation,
+        ),
+        (
+            "ElectronCurrent:Electrons@n1",
+            "simplify(diff(%s, Electrons@n1))" % current_equation,
+        ),
+        (
+            "ElectronCurrent:Potential@n0",
+            "simplify(diff(%s, Potential@n0))" % current_equation,
+        ),
+        (
+            "ElectronCurrent:Potential@n1",
+            "simplify(diff(%s, Potential@n1))" % current_equation,
+        ),
     ):
         devsim.edge_model(device=device, region=region, name=name, equation=equation)
 
@@ -186,91 +240,196 @@ def SetupCarrierResistorSystem(device, region):
     ####
     for name, equation in (
         ("NCharge", "-ElectronCharge * Electrons"),
-      ("NCharge:Electrons", "-ElectronCharge"),
+        ("NCharge:Electrons", "-ElectronCharge"),
     ):
         devsim.node_model(device=device, region=region, name=name, equation=equation)
 
     ####
     #### Electron Continuity Equation
     ####
-    devsim.equation(device=device, region=region, name="ElectronContinuityEquation", variable_name="Electrons",
-                    edge_model="ElectronCurrent", time_node_model="NCharge", variable_update="positive")
+    devsim.equation(
+        device=device,
+        region=region,
+        name="ElectronContinuityEquation",
+        variable_name="Electrons",
+        edge_model="ElectronCurrent",
+        time_node_model="NCharge",
+        variable_update="positive",
+    )
 
 
-def SetupInitialResistorContact(device, contact, use_circuit_bias=False, circuit_node=""):
+def SetupInitialResistorContact(
+    device, contact, use_circuit_bias=False, circuit_node=""
+):
     if circuit_node:
         bias_name = circuit_node
     else:
         bias_name = contact + "bias"
-    bias_node_model  = contact + "node_model"
+    bias_node_model = contact + "node_model"
 
-    devsim.contact_node_model(device=device, contact=contact, name=bias_node_model, equation="Potential - %s" % bias_name)
-    devsim.contact_node_model(device=device, contact=contact, name="%s:Potential" % bias_node_model, equation="1")
+    devsim.contact_node_model(
+        device=device,
+        contact=contact,
+        name=bias_node_model,
+        equation="Potential - %s" % bias_name,
+    )
+    devsim.contact_node_model(
+        device=device,
+        contact=contact,
+        name="%s:Potential" % bias_node_model,
+        equation="1",
+    )
     if use_circuit_bias:
-        devsim.contact_node_model(device=device, contact=contact, name="%s:%s" % (bias_node_model, bias_name), equation="-1")
-    #edge_model -device $device -region $region -name "contactcharge_edge_top"  -equation $conteq
+        devsim.contact_node_model(
+            device=device,
+            contact=contact,
+            name="%s:%s" % (bias_node_model, bias_name),
+            equation="-1",
+        )
+    # edge_model -device $device -region $region -name "contactcharge_edge_top"  -equation $conteq
     if use_circuit_bias:
-        devsim.contact_equation(device=device, contact=contact, name="PotentialEquation",
-                                node_model=bias_node_model, circuit_node=bias_name)
+        devsim.contact_equation(
+            device=device,
+            contact=contact,
+            name="PotentialEquation",
+            node_model=bias_node_model,
+            circuit_node=bias_name,
+        )
     else:
-        devsim.contact_equation(device=device, contact=contact, name="PotentialEquation",
-                                node_model=bias_node_model)
+        devsim.contact_equation(
+            device=device,
+            contact=contact,
+            name="PotentialEquation",
+            node_model=bias_node_model,
+        )
 
-def SetupCarrierResistorContact(device, contact, use_circuit_bias=False, circuit_node=""):
-    '''
-      Electron continuity equation at contact
-    '''
+
+def SetupCarrierResistorContact(
+    device, contact, use_circuit_bias=False, circuit_node=""
+):
+    """
+    Electron continuity equation at contact
+    """
     if circuit_node:
-        bias_name=circuit_node
+        bias_name = circuit_node
     else:
         bias_name = contact + "bias"
-    region=devsim.get_region_list(device=device, contact=contact)[0]
-    if 'celec' not in devsim.get_node_model_list(device=device, region=region):
-        devsim.node_model(device=device, region=region, name="celec", equation="0.5*(NetDoping+(NetDoping^2 + 4 * IntrinsicDensity^2)^(0.5))")
+    region = devsim.get_region_list(device=device, contact=contact)[0]
+    if "celec" not in devsim.get_node_model_list(device=device, region=region):
+        devsim.node_model(
+            device=device,
+            region=region,
+            name="celec",
+            equation="0.5*(NetDoping+(NetDoping^2 + 4 * IntrinsicDensity^2)^(0.5))",
+        )
 
     for name, equation in (
-        ("%snodeelectrons" % contact,           "Electrons - celec"),
-      ("%snodeelectrons:Electrons" % contact, "1."),
+        ("%snodeelectrons" % contact, "Electrons - celec"),
+        ("%snodeelectrons:Electrons" % contact, "1."),
     ):
-        devsim.contact_node_model(device=device, contact=contact, name=name, equation=equation)
+        devsim.contact_node_model(
+            device=device, contact=contact, name=name, equation=equation
+        )
 
     if use_circuit_bias:
-        devsim.contact_equation(device=device, contact=contact, name="ElectronContinuityEquation",
-                                node_model="%snodeelectrons" % contact, edge_current_model="ElectronCurrent", circuit_node=bias_name)
+        devsim.contact_equation(
+            device=device,
+            contact=contact,
+            name="ElectronContinuityEquation",
+            node_model="%snodeelectrons" % contact,
+            edge_current_model="ElectronCurrent",
+            circuit_node=bias_name,
+        )
     else:
-        devsim.contact_equation(device=device, contact=contact, name="ElectronContinuityEquation",
-                                node_model="%snodeelectrons" % contact, edge_current_model="ElectronCurrent")
+        devsim.contact_equation(
+            device=device,
+            contact=contact,
+            name="ElectronContinuityEquation",
+            node_model="%snodeelectrons" % contact,
+            edge_current_model="ElectronCurrent",
+        )
+
 
 def SetupContinuousPotentialAtInterface(device, interface):
     # type continuous means that regular equations in both regions are swapped into the primary region
-    devsim.interface_model(device=device, interface=interface, name="continuousPotential", equation="Potential@r0-Potential@r1")
-    devsim.interface_model(device=device, interface=interface, name="continuousPotential:Potential@r0", equation= "1")
-    devsim.interface_model(device=device, interface=interface, name="continuousPotential:Potential@r1", equation="-1")
-    devsim.interface_equation(device=device, interface=interface, name="PotentialEquation", interface_model="continuousPotential", type="continuous")
+    devsim.interface_model(
+        device=device,
+        interface=interface,
+        name="continuousPotential",
+        equation="Potential@r0-Potential@r1",
+    )
+    devsim.interface_model(
+        device=device,
+        interface=interface,
+        name="continuousPotential:Potential@r0",
+        equation="1",
+    )
+    devsim.interface_model(
+        device=device,
+        interface=interface,
+        name="continuousPotential:Potential@r1",
+        equation="-1",
+    )
+    devsim.interface_equation(
+        device=device,
+        interface=interface,
+        name="PotentialEquation",
+        interface_model="continuousPotential",
+        type="continuous",
+    )
+
 
 def SetupContinuousElectronsAtInterface(device, interface):
     # type continuous means that regular equations in both regions are swapped into the primary region
-    devsim.interface_model(device=device, interface=interface, name="continuousElectrons", equation="Electrons@r0-Electrons@r1")
-    devsim.interface_model(device=device, interface=interface, name="continuousElectrons:Electrons@r0", equation= "1")
-    devsim.interface_model(device=device, interface=interface, name="continuousElectrons:Electrons@r1", equation="-1")
-    devsim.interface_equation(device=device, interface=interface, name="ElectronContinuityEquation", interface_model="continuousElectrons", type="continuous")
+    devsim.interface_model(
+        device=device,
+        interface=interface,
+        name="continuousElectrons",
+        equation="Electrons@r0-Electrons@r1",
+    )
+    devsim.interface_model(
+        device=device,
+        interface=interface,
+        name="continuousElectrons:Electrons@r0",
+        equation="1",
+    )
+    devsim.interface_model(
+        device=device,
+        interface=interface,
+        name="continuousElectrons:Electrons@r1",
+        equation="-1",
+    )
+    devsim.interface_equation(
+        device=device,
+        interface=interface,
+        name="ElectronContinuityEquation",
+        interface_model="continuousElectrons",
+        type="continuous",
+    )
+
 
 def SetupElectronSRVAtInterface(device, interface):
-    '''
-      Surface Recombination Velocity At Interface
-    '''
+    """
+    Surface Recombination Velocity At Interface
+    """
     devsim.set_parameter(device=device, name="alpha_n", value=1e-7)
-    iexp="(alpha_n@r0)*(Electrons@r0-Electrons@r1)"
+    iexp = "(alpha_n@r0)*(Electrons@r0-Electrons@r1)"
     for name, equation in (
         ("srvElectrons", iexp),
-      ("srvElectrons2", "srvElectrons"),
-      ("srvElectrons:Electrons@r0", "diff(%s,Electrons@r0)" % iexp),
-      ("srvElectrons:Electrons@r1", "diff(%s,Electrons@r1)" % iexp),
-      ("srvElectrons2:Electrons@r0", "srvElectrons:Electrons@r0"),
-      ("srvElectrons2:Electrons@r1", "srvElectrons:Electrons@r1"),
+        ("srvElectrons2", "srvElectrons"),
+        ("srvElectrons:Electrons@r0", "diff(%s,Electrons@r0)" % iexp),
+        ("srvElectrons:Electrons@r1", "diff(%s,Electrons@r1)" % iexp),
+        ("srvElectrons2:Electrons@r0", "srvElectrons:Electrons@r0"),
+        ("srvElectrons2:Electrons@r1", "srvElectrons:Electrons@r1"),
     ):
-        devsim.interface_model(device=device, interface=interface, name=name, equation=equation)
+        devsim.interface_model(
+            device=device, interface=interface, name=name, equation=equation
+        )
 
-    devsim.interface_equation(device=device, interface=interface, name="ElectronContinuityEquation", interface_model="srvElectrons2", type="fluxterm")
-
-
+    devsim.interface_equation(
+        device=device,
+        interface=interface,
+        name="ElectronContinuityEquation",
+        interface_model="srvElectrons2",
+        type="fluxterm",
+    )

--- a/testing/testfunc.py
+++ b/testing/testfunc.py
@@ -2,10 +2,22 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from devsim import add_1d_contact, add_1d_mesh_line, add_1d_region, create_1d_mesh, create_device, finalize_mesh, node_model, print_node_values, register_function, symdiff
+from devsim import (
+    add_1d_contact,
+    add_1d_mesh_line,
+    add_1d_region,
+    create_1d_mesh,
+    create_device,
+    finalize_mesh,
+    node_model,
+    print_node_values,
+    register_function,
+    symdiff,
+)
 
 from math import cos
 from math import sin
+
 device = "MyDevice"
 region = "MyRegion"
 
@@ -16,9 +28,9 @@ region = "MyRegion"
 create_1d_mesh(mesh="dog")
 add_1d_mesh_line(mesh="dog", pos=0.0, ps=0.1, tag="top")
 add_1d_mesh_line(mesh="dog", pos=1.0, ps=0.1, tag="bot")
-add_1d_contact  (mesh="dog", name="top", material="metal", tag="top")
-add_1d_contact  (mesh="dog", name="bot", material="metal", tag="bot")
-add_1d_region   (mesh="dog", material="Si", region=region, tag1="top", tag2="bot")
+add_1d_contact(mesh="dog", name="top", material="metal", tag="top")
+add_1d_contact(mesh="dog", name="bot", material="metal", tag="bot")
+add_1d_region(mesh="dog", material="Si", region=region, tag1="top", tag2="bot")
 finalize_mesh(mesh="dog")
 create_device(mesh="dog", device=device)
 
@@ -27,18 +39,20 @@ symdiff(expr="declare(sin(x))")
 symdiff(expr="define(cos(x), -sin(x))")
 symdiff(expr="define(sin(x),  cos(x))")
 
-#proc cos {x} {
+# proc cos {x} {
 #  return [expr cos($x)]
-#}
+# }
 
-#proc sin {x} {
+
+# proc sin {x} {
 #  return [expr sin($x)]
-#}
+# }
 #
 # This is a degenerate case causing the result object of this procedure to be the same as
 # one of our original arguments
 def gee(x, y):
     return x
+
 
 register_function(name="cos", procedure=cos, nargs=1)
 register_function(name="sin", procedure=sin, nargs=1)
@@ -49,5 +63,3 @@ node_model(device=device, region=region, name="bar", equation="diff(sin(x),x)")
 print_node_values(device=device, region=region, name="gee")
 print_node_values(device=device, region=region, name="foo")
 print_node_values(device=device, region=region, name="bar")
-
-

--- a/testing/testfunc_extended.py
+++ b/testing/testfunc_extended.py
@@ -1,8 +1,8 @@
-
 ###
 ### Test to be sure functions can be registered in extended precision
 ###
 import devsim
+
 devsim.set_parameter(name="extended_model", value=True)
 
-import testfunc
+import testfunc  # noqa: E402, F401

--- a/testing/transient_circ.py
+++ b/testing/transient_circ.py
@@ -7,25 +7,61 @@ import test_common
 
 # ssac circuit only
 devsim.circuit_element(name="V1", n1=1, n2=0, value=1.0, acreal=1.0)
-#lambda = 0.04
+# lambda = 0.04
 devsim.circuit_element(name="R1", n1=1, n2=2, value=5)
 devsim.circuit_element(name="C1", n1=2, n2=0, value=5)
 
 print("transient_dc")
-devsim.solve(type="transient_dc", absolute_error=1.0, relative_error=1e-14, maximum_iterations=3)
+devsim.solve(
+    type="transient_dc", absolute_error=1.0, relative_error=1e-14, maximum_iterations=3
+)
 test_common.print_circuit_solution()
 
 devsim.circuit_alter(name="V1", value=0.0)
 
 print("transient_bdf1")
-devsim.solve(type="transient_bdf1", absolute_error=1.0, relative_error=1e-14, maximum_iterations=3, tdelta=1e-3, charge_error=1e-2)
+devsim.solve(
+    type="transient_bdf1",
+    absolute_error=1.0,
+    relative_error=1e-14,
+    maximum_iterations=3,
+    tdelta=1e-3,
+    charge_error=1e-2,
+)
 test_common.print_circuit_solution()
-devsim.solve(type="transient_bdf1", absolute_error=1.0, relative_error=1e-14, maximum_iterations=3, tdelta=1e-3, charge_error=1e-2)
+devsim.solve(
+    type="transient_bdf1",
+    absolute_error=1.0,
+    relative_error=1e-14,
+    maximum_iterations=3,
+    tdelta=1e-3,
+    charge_error=1e-2,
+)
 test_common.print_circuit_solution()
-devsim.solve(type="transient_bdf1", absolute_error=1.0, relative_error=1e-14, maximum_iterations=3, tdelta=1e-3, charge_error=1e-2)
+devsim.solve(
+    type="transient_bdf1",
+    absolute_error=1.0,
+    relative_error=1e-14,
+    maximum_iterations=3,
+    tdelta=1e-3,
+    charge_error=1e-2,
+)
 test_common.print_circuit_solution()
-devsim.solve(type="transient_bdf1", absolute_error=1.0, relative_error=1e-14, maximum_iterations=3, tdelta=1e-3, charge_error=1e-2)
+devsim.solve(
+    type="transient_bdf1",
+    absolute_error=1.0,
+    relative_error=1e-14,
+    maximum_iterations=3,
+    tdelta=1e-3,
+    charge_error=1e-2,
+)
 test_common.print_circuit_solution()
-devsim.solve(type="transient_bdf1", absolute_error=1.0, relative_error=1e-14, maximum_iterations=3, tdelta=1e-3, charge_error=1e-2)
+devsim.solve(
+    type="transient_bdf1",
+    absolute_error=1.0,
+    relative_error=1e-14,
+    maximum_iterations=3,
+    tdelta=1e-3,
+    charge_error=1e-2,
+)
 test_common.print_circuit_solution()
-

--- a/testing/transient_circ2.py
+++ b/testing/transient_circ2.py
@@ -7,25 +7,61 @@ import test_common
 
 # ssac circuit only
 devsim.circuit_element(name="V1", n1=1, n2=0, value=1.0, acreal=1.0)
-#lambda = 0.04
+# lambda = 0.04
 devsim.circuit_element(name="R1", n1=1, n2=2, value=5)
 devsim.circuit_element(name="C1", n1=2, n2=0, value=5)
 
 print("transient_dc")
-devsim.solve(type="transient_dc", absolute_error=1.0, relative_error=1e-14, maximum_iterations=3)
+devsim.solve(
+    type="transient_dc", absolute_error=1.0, relative_error=1e-14, maximum_iterations=3
+)
 test_common.print_circuit_solution()
 
 devsim.circuit_alter(name="V1", value=0.0)
 
 print("transient_tr")
-devsim.solve(type="transient_tr", absolute_error=1.0, relative_error=1e-14, maximum_iterations=3, tdelta=1e-3, charge_error=1e-2)
+devsim.solve(
+    type="transient_tr",
+    absolute_error=1.0,
+    relative_error=1e-14,
+    maximum_iterations=3,
+    tdelta=1e-3,
+    charge_error=1e-2,
+)
 test_common.print_circuit_solution()
-devsim.solve(type="transient_tr", absolute_error=1.0, relative_error=1e-14, maximum_iterations=3, tdelta=1e-3, charge_error=1e-2)
+devsim.solve(
+    type="transient_tr",
+    absolute_error=1.0,
+    relative_error=1e-14,
+    maximum_iterations=3,
+    tdelta=1e-3,
+    charge_error=1e-2,
+)
 test_common.print_circuit_solution()
-devsim.solve(type="transient_tr", absolute_error=1.0, relative_error=1e-14, maximum_iterations=3, tdelta=1e-3, charge_error=1e-2)
+devsim.solve(
+    type="transient_tr",
+    absolute_error=1.0,
+    relative_error=1e-14,
+    maximum_iterations=3,
+    tdelta=1e-3,
+    charge_error=1e-2,
+)
 test_common.print_circuit_solution()
-devsim.solve(type="transient_tr", absolute_error=1.0, relative_error=1e-14, maximum_iterations=3, tdelta=1e-3, charge_error=1e-2)
+devsim.solve(
+    type="transient_tr",
+    absolute_error=1.0,
+    relative_error=1e-14,
+    maximum_iterations=3,
+    tdelta=1e-3,
+    charge_error=1e-2,
+)
 test_common.print_circuit_solution()
-devsim.solve(type="transient_tr", absolute_error=1.0, relative_error=1e-14, maximum_iterations=3, tdelta=1e-3, charge_error=1e-2)
+devsim.solve(
+    type="transient_tr",
+    absolute_error=1.0,
+    relative_error=1e-14,
+    maximum_iterations=3,
+    tdelta=1e-3,
+    charge_error=1e-2,
+)
 test_common.print_circuit_solution()
-

--- a/testing/transient_circ3.py
+++ b/testing/transient_circ3.py
@@ -8,37 +8,118 @@ import math
 
 # ssac circuit only
 devsim.circuit_element(name="V1", n1=1, n2=0, value=1.0, acreal=1.0)
-#lambda = 0.04
+# lambda = 0.04
 devsim.circuit_element(name="R1", n1=1, n2=2, value=5)
 devsim.circuit_element(name="C1", n1=2, n2=0, value=5)
 
 print("transient_dc")
-devsim.solve(type="transient_dc", absolute_error=1.0, relative_error=1e-14, maximum_iterations=3)
+devsim.solve(
+    type="transient_dc", absolute_error=1.0, relative_error=1e-14, maximum_iterations=3
+)
 test_common.print_circuit_solution()
 
 devsim.circuit_alter(name="V1", value=0.0)
 
-gamma=2 - math.sqrt(2.0)
+gamma = 2 - math.sqrt(2.0)
 
 print("transient_tr, transient_bdf2")
-devsim.solve(type="transient_tr",   absolute_error=1.0, relative_error=1e-14, maximum_iterations=3, tdelta=1e-3, gamma=gamma, charge_error=1e-2)
+devsim.solve(
+    type="transient_tr",
+    absolute_error=1.0,
+    relative_error=1e-14,
+    maximum_iterations=3,
+    tdelta=1e-3,
+    gamma=gamma,
+    charge_error=1e-2,
+)
 test_common.print_circuit_solution()
-devsim.solve(type="transient_bdf2", absolute_error=1.0, relative_error=1e-14, maximum_iterations=3, tdelta=1e-3, gamma=gamma, charge_error=1e-2)
+devsim.solve(
+    type="transient_bdf2",
+    absolute_error=1.0,
+    relative_error=1e-14,
+    maximum_iterations=3,
+    tdelta=1e-3,
+    gamma=gamma,
+    charge_error=1e-2,
+)
 test_common.print_circuit_solution()
-devsim.solve(type="transient_tr",   absolute_error=1.0, relative_error=1e-14, maximum_iterations=3, tdelta=1e-3, gamma=gamma, charge_error=1e-2)
+devsim.solve(
+    type="transient_tr",
+    absolute_error=1.0,
+    relative_error=1e-14,
+    maximum_iterations=3,
+    tdelta=1e-3,
+    gamma=gamma,
+    charge_error=1e-2,
+)
 test_common.print_circuit_solution()
-devsim.solve(type="transient_bdf2", absolute_error=1.0, relative_error=1e-14, maximum_iterations=3, tdelta=1e-3, gamma=gamma, charge_error=1e-2)
+devsim.solve(
+    type="transient_bdf2",
+    absolute_error=1.0,
+    relative_error=1e-14,
+    maximum_iterations=3,
+    tdelta=1e-3,
+    gamma=gamma,
+    charge_error=1e-2,
+)
 test_common.print_circuit_solution()
-devsim.solve(type="transient_tr",   absolute_error=1.0, relative_error=1e-14, maximum_iterations=3, tdelta=1e-3, gamma=gamma, charge_error=1e-2)
+devsim.solve(
+    type="transient_tr",
+    absolute_error=1.0,
+    relative_error=1e-14,
+    maximum_iterations=3,
+    tdelta=1e-3,
+    gamma=gamma,
+    charge_error=1e-2,
+)
 test_common.print_circuit_solution()
-devsim.solve(type="transient_bdf2", absolute_error=1.0, relative_error=1e-14, maximum_iterations=3, tdelta=1e-3, gamma=gamma, charge_error=1e-2)
+devsim.solve(
+    type="transient_bdf2",
+    absolute_error=1.0,
+    relative_error=1e-14,
+    maximum_iterations=3,
+    tdelta=1e-3,
+    gamma=gamma,
+    charge_error=1e-2,
+)
 test_common.print_circuit_solution()
-devsim.solve(type="transient_tr",   absolute_error=1.0, relative_error=1e-14, maximum_iterations=3, tdelta=1e-3, gamma=gamma, charge_error=1e-2)
+devsim.solve(
+    type="transient_tr",
+    absolute_error=1.0,
+    relative_error=1e-14,
+    maximum_iterations=3,
+    tdelta=1e-3,
+    gamma=gamma,
+    charge_error=1e-2,
+)
 test_common.print_circuit_solution()
-devsim.solve(type="transient_bdf2", absolute_error=1.0, relative_error=1e-14, maximum_iterations=3, tdelta=1e-3, gamma=gamma, charge_error=1e-2)
+devsim.solve(
+    type="transient_bdf2",
+    absolute_error=1.0,
+    relative_error=1e-14,
+    maximum_iterations=3,
+    tdelta=1e-3,
+    gamma=gamma,
+    charge_error=1e-2,
+)
 test_common.print_circuit_solution()
-devsim.solve(type="transient_tr",   absolute_error=1.0, relative_error=1e-14, maximum_iterations=3, tdelta=1e-3, gamma=gamma, charge_error=1e-2)
+devsim.solve(
+    type="transient_tr",
+    absolute_error=1.0,
+    relative_error=1e-14,
+    maximum_iterations=3,
+    tdelta=1e-3,
+    gamma=gamma,
+    charge_error=1e-2,
+)
 test_common.print_circuit_solution()
-devsim.solve(type="transient_bdf2", absolute_error=1.0, relative_error=1e-14, maximum_iterations=3, tdelta=1e-3, gamma=gamma, charge_error=1e-2)
+devsim.solve(
+    type="transient_bdf2",
+    absolute_error=1.0,
+    relative_error=1e-14,
+    maximum_iterations=3,
+    tdelta=1e-3,
+    gamma=gamma,
+    charge_error=1e-2,
+)
 test_common.print_circuit_solution()
-

--- a/testing/transient_rc.py
+++ b/testing/transient_rc.py
@@ -6,6 +6,7 @@ import devsim
 import math
 from collections import defaultdict
 
+
 class RCCircuit:
     def __init__(self):
         self.R = 5
@@ -19,39 +20,76 @@ class RCCircuit:
     def create_circuit(self):
         # ssac circuit only
         devsim.circuit_element(name="V1", n1=1, n2=0, value=self.V)
-        #lambda = 0.04
+        # lambda = 0.04
         devsim.circuit_element(name="R1", n1=1, n2=2, value=self.R)
         devsim.circuit_element(name="C1", n1=2, n2=0, value=self.C)
 
-
     def calculate_expected_voltage_current(self, vprev, tstep):
-        '''
+        """
         assumes simulation voltage is 0.0
-        '''
-        v = vprev * math.exp(-tstep/(self.R*self.C))
-        i = v/self.R
-        return(v, i)
-
+        """
+        v = vprev * math.exp(-tstep / (self.R * self.C))
+        i = v / self.R
+        return (v, i)
 
 
 def bdf1(tstep):
-    devsim.solve(type="transient_bdf1", absolute_error=1.0, relative_error=1e-14, maximum_iterations=3, tdelta=tstep, charge_error=1e-2)
+    devsim.solve(
+        type="transient_bdf1",
+        absolute_error=1.0,
+        relative_error=1e-14,
+        maximum_iterations=3,
+        tdelta=tstep,
+        charge_error=1e-2,
+    )
+
 
 def bdf1twice(tstep):
-    bdf1(0.5*tstep)
-    bdf1(0.5*tstep)
+    bdf1(0.5 * tstep)
+    bdf1(0.5 * tstep)
+
 
 def tr(tstep):
-    devsim.solve(type="transient_tr", absolute_error=1.0, relative_error=1e-14, maximum_iterations=3, tdelta=tstep, charge_error=1e-2)
+    devsim.solve(
+        type="transient_tr",
+        absolute_error=1.0,
+        relative_error=1e-14,
+        maximum_iterations=3,
+        tdelta=tstep,
+        charge_error=1e-2,
+    )
+
 
 def trbdf(tstep):
     gamma = 2 - math.sqrt(2.0)
-    devsim.solve(type="transient_tr",   absolute_error=1.0, relative_error=1e-14, maximum_iterations=3, tdelta=tstep, gamma=gamma, charge_error=1e-2)
-    devsim.solve(type="transient_bdf2", absolute_error=1.0, relative_error=1e-14, maximum_iterations=3, tdelta=tstep, gamma=gamma, charge_error=1e-2)
+    devsim.solve(
+        type="transient_tr",
+        absolute_error=1.0,
+        relative_error=1e-14,
+        maximum_iterations=3,
+        tdelta=tstep,
+        gamma=gamma,
+        charge_error=1e-2,
+    )
+    devsim.solve(
+        type="transient_bdf2",
+        absolute_error=1.0,
+        relative_error=1e-14,
+        maximum_iterations=3,
+        tdelta=tstep,
+        gamma=gamma,
+        charge_error=1e-2,
+    )
+
 
 def run_simulation(circuit, tstep, tsolve1, tsolve2):
     circuit.set_circuit_voltage(1.0)
-    devsim.solve(type="transient_dc", absolute_error=1.0, relative_error=1e-14, maximum_iterations=3)
+    devsim.solve(
+        type="transient_dc",
+        absolute_error=1.0,
+        relative_error=1e-14,
+        maximum_iterations=3,
+    )
 
     vprev = circuit.V
     circuit.set_circuit_voltage(0.0)
@@ -59,35 +97,57 @@ def run_simulation(circuit, tstep, tsolve1, tsolve2):
     vals = []
 
     for i in range(10):
-        if (i == 0):
+        if i == 0:
             tsolve1(tstep)
         else:
             tsolve2(tstep)
-        (vnew, inew) = circuit.calculate_expected_voltage_current(vprev=vprev, tstep=tstep)
-        vc = devsim.get_circuit_node_value(node=2, solution='dcop')
-        ic = devsim.get_circuit_node_value(node='V1.I', solution='dcop')
-        vals.append((vc, vnew, (vc-vnew)/vnew, ic, inew, (ic-inew)/inew))
+        (vnew, inew) = circuit.calculate_expected_voltage_current(
+            vprev=vprev, tstep=tstep
+        )
+        vc = devsim.get_circuit_node_value(node=2, solution="dcop")
+        ic = devsim.get_circuit_node_value(node="V1.I", solution="dcop")
+        vals.append((vc, vnew, (vc - vnew) / vnew, ic, inew, (ic - inew) / inew))
         vprev = vnew
     return vals
 
+
 circuit = RCCircuit()
-circuit.V=1.0
-circuit.R=5
-circuit.C=5
+circuit.V = 1.0
+circuit.R = 5
+circuit.C = 5
 
 circuit.create_circuit()
 
 results = defaultdict(list)
 for tstep in (0.1, 0.01, 0.001, 0.0001):
     print("BDF1 Method")
-    results['bdf1'].append((tstep, run_simulation(circuit=circuit, tstep=tstep, tsolve1=bdf1twice, tsolve2=bdf1)))
+    results["bdf1"].append(
+        (
+            tstep,
+            run_simulation(
+                circuit=circuit, tstep=tstep, tsolve1=bdf1twice, tsolve2=bdf1
+            ),
+        )
+    )
 
     print("TR Method")
     # the initial timestep should be bdf1 because of the large step in the bias voltage
-    results['tr'].append((tstep, run_simulation(circuit=circuit, tstep=tstep, tsolve1=bdf1twice, tsolve2=tr)))
+    results["tr"].append(
+        (
+            tstep,
+            run_simulation(circuit=circuit, tstep=tstep, tsolve1=bdf1twice, tsolve2=tr),
+        )
+    )
 
     print("TRBDF Method")
-    results['trbdf'].append((tstep, run_simulation(circuit=circuit, tstep=tstep, tsolve1=bdf1twice, tsolve2=trbdf)))
+    results["trbdf"].append(
+        (
+            tstep,
+            run_simulation(
+                circuit=circuit, tstep=tstep, tsolve1=bdf1twice, tsolve2=trbdf
+            ),
+        )
+    )
 
 for k, datasets in results.items():
     for tstep, vals in datasets:
@@ -95,4 +155,3 @@ for k, datasets in results.items():
         for i in vals:
             print("%1.5e %1.5e %1.5e %1.5e %1.5e %1.5e" % i)
         print()
-

--- a/testing/trimesh1.py
+++ b/testing/trimesh1.py
@@ -4,45 +4,111 @@
 
 import devsim
 
-device="MyDevice"
-region="MyRegion"
+device = "MyDevice"
+region = "MyRegion"
 
 devsim.load_devices(file="trimesh1.msh")
 devsim.print_node_values(device="MyDevice", region="MyRegion", name="NodeVolume")
 devsim.print_edge_values(device="MyDevice", region="MyRegion", name="EdgeCouple")
 
-devsim.set_parameter(device=device, region=region, name="Permittivity",   value=3.9*8.85e-14)
+devsim.set_parameter(
+    device=device, region=region, name="Permittivity", value=3.9 * 8.85e-14
+)
 devsim.set_parameter(device=device, region=region, name="ElectricCharge", value=1.6e-19)
 
 devsim.node_solution(device=device, region=region, name="Potential")
 devsim.edge_from_node_model(device=device, region=region, node_model="Potential")
 
-devsim.edge_model(device=device, region=region, name="ElectricField", equation="(Potential@n0 - Potential@n1)*EdgeInverseLength")
-devsim.edge_model(device=device, region=region, name="ElectricField:Potential@n0", equation="EdgeInverseLength")
-devsim.edge_model(device=device, region=region, name="ElectricField:Potential@n1", equation="-EdgeInverseLength")
+devsim.edge_model(
+    device=device,
+    region=region,
+    name="ElectricField",
+    equation="(Potential@n0 - Potential@n1)*EdgeInverseLength",
+)
+devsim.edge_model(
+    device=device,
+    region=region,
+    name="ElectricField:Potential@n0",
+    equation="EdgeInverseLength",
+)
+devsim.edge_model(
+    device=device,
+    region=region,
+    name="ElectricField:Potential@n1",
+    equation="-EdgeInverseLength",
+)
 
 devsim.set_parameter(device=device, region=region, name="topbias", value=1.0e-0)
 devsim.set_parameter(device=device, region=region, name="botbias", value=0.0)
 
-devsim.edge_model(device=device, region=region, name="PotentialEdgeFlux", equation="Permittivity*ElectricField")
-devsim.edge_model(device=device, region=region, name="PotentialEdgeFlux:Potential@n0", equation="diff(Permittivity*ElectricField, Potential@n0)")
-devsim.edge_model(device=device, region=region, name="PotentialEdgeFlux:Potential@n1", equation="-PotentialEdgeFlux:Potential@n0")
+devsim.edge_model(
+    device=device,
+    region=region,
+    name="PotentialEdgeFlux",
+    equation="Permittivity*ElectricField",
+)
+devsim.edge_model(
+    device=device,
+    region=region,
+    name="PotentialEdgeFlux:Potential@n0",
+    equation="diff(Permittivity*ElectricField, Potential@n0)",
+)
+devsim.edge_model(
+    device=device,
+    region=region,
+    name="PotentialEdgeFlux:Potential@n1",
+    equation="-PotentialEdgeFlux:Potential@n0",
+)
 
-devsim.equation(device=device, region=region, name="PotentialEquation", variable_name="Potential", edge_model="PotentialEdgeFlux", variable_update="default")
+devsim.equation(
+    device=device,
+    region=region,
+    name="PotentialEquation",
+    variable_name="Potential",
+    edge_model="PotentialEdgeFlux",
+    variable_update="default",
+)
 
-devsim.node_model(device=device, region=region, name="topnode_model"          , equation="Potential - topbias")
-devsim.node_model(device=device, region=region, name="topnode_model:Potential", equation="1")
+devsim.node_model(
+    device=device, region=region, name="topnode_model", equation="Potential - topbias"
+)
+devsim.node_model(
+    device=device, region=region, name="topnode_model:Potential", equation="1"
+)
 
-devsim.node_model(device=device, region=region, name="botnode_model"          , equation="Potential - botbias")
-devsim.node_model(device=device, region=region, name="botnode_model:Potential", equation="1")
+devsim.node_model(
+    device=device, region=region, name="botnode_model", equation="Potential - botbias"
+)
+devsim.node_model(
+    device=device, region=region, name="botnode_model:Potential", equation="1"
+)
 
-devsim.contact_equation(device=device, contact="top", name="PotentialEquation", node_model="topnode_model", edge_charge_model="PotentialEdgeFlux")
-devsim.contact_equation(device=device, contact="bot", name="PotentialEquation", node_model="botnode_model", edge_charge_model="PotentialEdgeFlux")
+devsim.contact_equation(
+    device=device,
+    contact="top",
+    name="PotentialEquation",
+    node_model="topnode_model",
+    edge_charge_model="PotentialEdgeFlux",
+)
+devsim.contact_equation(
+    device=device,
+    contact="bot",
+    name="PotentialEquation",
+    node_model="botnode_model",
+    edge_charge_model="PotentialEdgeFlux",
+)
 
 devsim.solve(type="dc", absolute_error=1.0, relative_error=1e-10, maximum_iterations=30)
 
-print(devsim.get_contact_charge(device=device, contact="top", equation="PotentialEquation"))
-print(devsim.get_contact_charge(device=device, contact="bot", equation="PotentialEquation"))
+print(
+    devsim.get_contact_charge(
+        device=device, contact="top", equation="PotentialEquation"
+    )
+)
+print(
+    devsim.get_contact_charge(
+        device=device, contact="bot", equation="PotentialEquation"
+    )
+)
 
 devsim.write_devices(file="trimesh2.msh", type="devsim_data")
-

--- a/testing/trimesh2.py
+++ b/testing/trimesh2.py
@@ -4,45 +4,111 @@
 
 import devsim
 
-device="MyDevice"
-region="MyRegion"
+device = "MyDevice"
+region = "MyRegion"
 
 devsim.load_devices(file="trimesh2.msh")
 devsim.print_node_values(device="MyDevice", region="MyRegion", name="NodeVolume")
 devsim.print_edge_values(device="MyDevice", region="MyRegion", name="EdgeCouple")
 
-devsim.set_parameter(device=device, region=region, name="Permittivity",   value=3.9*8.85e-14)
+devsim.set_parameter(
+    device=device, region=region, name="Permittivity", value=3.9 * 8.85e-14
+)
 devsim.set_parameter(device=device, region=region, name="ElectricCharge", value=1.6e-19)
 
 devsim.node_solution(device=device, region=region, name="Potential")
 devsim.edge_from_node_model(device=device, region=region, node_model="Potential")
 
-devsim.edge_model(device=device, region=region, name="ElectricField", equation="(Potential@n0 - Potential@n1)*EdgeInverseLength")
-devsim.edge_model(device=device, region=region, name="ElectricField:Potential@n0", equation="EdgeInverseLength")
-devsim.edge_model(device=device, region=region, name="ElectricField:Potential@n1", equation="-EdgeInverseLength")
+devsim.edge_model(
+    device=device,
+    region=region,
+    name="ElectricField",
+    equation="(Potential@n0 - Potential@n1)*EdgeInverseLength",
+)
+devsim.edge_model(
+    device=device,
+    region=region,
+    name="ElectricField:Potential@n0",
+    equation="EdgeInverseLength",
+)
+devsim.edge_model(
+    device=device,
+    region=region,
+    name="ElectricField:Potential@n1",
+    equation="-EdgeInverseLength",
+)
 
 devsim.set_parameter(device=device, region=region, name="topbias", value=1.0e-0)
 devsim.set_parameter(device=device, region=region, name="botbias", value=0.0)
 
-devsim.edge_model(device=device, region=region, name="PotentialEdgeFlux", equation="Permittivity*ElectricField")
-devsim.edge_model(device=device, region=region, name="PotentialEdgeFlux:Potential@n0", equation="diff(Permittivity*ElectricField, Potential@n0)")
-devsim.edge_model(device=device, region=region, name="PotentialEdgeFlux:Potential@n1", equation="-PotentialEdgeFlux:Potential@n0")
+devsim.edge_model(
+    device=device,
+    region=region,
+    name="PotentialEdgeFlux",
+    equation="Permittivity*ElectricField",
+)
+devsim.edge_model(
+    device=device,
+    region=region,
+    name="PotentialEdgeFlux:Potential@n0",
+    equation="diff(Permittivity*ElectricField, Potential@n0)",
+)
+devsim.edge_model(
+    device=device,
+    region=region,
+    name="PotentialEdgeFlux:Potential@n1",
+    equation="-PotentialEdgeFlux:Potential@n0",
+)
 
-devsim.equation(device=device, region=region, name="PotentialEquation", variable_name="Potential", edge_model="PotentialEdgeFlux", variable_update="default")
+devsim.equation(
+    device=device,
+    region=region,
+    name="PotentialEquation",
+    variable_name="Potential",
+    edge_model="PotentialEdgeFlux",
+    variable_update="default",
+)
 
-devsim.node_model(device=device, region=region, name="topnode_model"          , equation="Potential - topbias")
-devsim.node_model(device=device, region=region, name="topnode_model:Potential", equation="1")
+devsim.node_model(
+    device=device, region=region, name="topnode_model", equation="Potential - topbias"
+)
+devsim.node_model(
+    device=device, region=region, name="topnode_model:Potential", equation="1"
+)
 
-devsim.node_model(device=device, region=region, name="botnode_model"          , equation="Potential - botbias")
-devsim.node_model(device=device, region=region, name="botnode_model:Potential", equation="1")
+devsim.node_model(
+    device=device, region=region, name="botnode_model", equation="Potential - botbias"
+)
+devsim.node_model(
+    device=device, region=region, name="botnode_model:Potential", equation="1"
+)
 
-devsim.contact_equation(device=device, contact="top", name="PotentialEquation", node_model="topnode_model", edge_charge_model="PotentialEdgeFlux")
-devsim.contact_equation(device=device, contact="bot", name="PotentialEquation", node_model="botnode_model", edge_charge_model="PotentialEdgeFlux")
+devsim.contact_equation(
+    device=device,
+    contact="top",
+    name="PotentialEquation",
+    node_model="topnode_model",
+    edge_charge_model="PotentialEdgeFlux",
+)
+devsim.contact_equation(
+    device=device,
+    contact="bot",
+    name="PotentialEquation",
+    node_model="botnode_model",
+    edge_charge_model="PotentialEdgeFlux",
+)
 
 devsim.solve(type="dc", absolute_error=1.0, relative_error=1e-10, maximum_iterations=30)
 
-print(devsim.get_contact_charge(device=device, contact="top", equation="PotentialEquation"))
-print(devsim.get_contact_charge(device=device, contact="bot", equation="PotentialEquation"))
+print(
+    devsim.get_contact_charge(
+        device=device, contact="top", equation="PotentialEquation"
+    )
+)
+print(
+    devsim.get_contact_charge(
+        device=device, contact="bot", equation="PotentialEquation"
+    )
+)
 
 devsim.write_devices(file="trimesh3.msh", type="devsim_data")
-

--- a/testing/utf8_2.py
+++ b/testing/utf8_2.py
@@ -5,34 +5,51 @@
 
 ##Title: cap1.py
 ##Purpose: Simple example for 1D capacitor
-from devsim import add_1d_contact, add_1d_mesh_line, add_1d_region, contact_equation, create_1d_mesh, create_device, edge_from_node_model, edge_model, equation, finalize_mesh, get_contact_charge, get_parameter, node_model, node_solution, set_parameter, solve
+from devsim import (
+    add_1d_contact,
+    add_1d_mesh_line,
+    add_1d_region,
+    contact_equation,
+    create_1d_mesh,
+    create_device,
+    edge_from_node_model,
+    edge_model,
+    equation,
+    finalize_mesh,
+    get_contact_charge,
+    get_parameter,
+    node_model,
+    node_solution,
+    set_parameter,
+    solve,
+)
 
 
-device_info = {'device' : 'MyDevice'}
+device_info = {"device": "MyDevice"}
 region_info = device_info
-region_info['region'] = "MyRegion"
+region_info["region"] = "MyRegion"
 
-#print region_info
+# print region_info
 device = "MyDevice"
 region = "MyRegion"
 
 create_1d_mesh(mesh="dog")
 for p, s, t in ((0.0, 0.1, "top"), (1.0, 0.1, "bot")):
-    add_1d_mesh_line(mesh = "dog", pos=p, ps = s, tag = t)
+    add_1d_mesh_line(mesh="dog", pos=p, ps=s, tag=t)
 
-for t in ('top', 'bot'):
-    add_1d_contact(  mesh = "dog", name=t, material="metal", tag=t)
+for t in ("top", "bot"):
+    add_1d_contact(mesh="dog", name=t, material="metal", tag=t)
 
-add_1d_region(   mesh = "dog", material="Si", region = region, tag1 ="top" , tag2 = "bot")
+add_1d_region(mesh="dog", material="Si", region=region, tag1="top", tag2="bot")
 finalize_mesh(mesh="dog")
-create_device(mesh="dog", device = device)
+create_device(mesh="dog", device=device)
 
-#for i in get_device_list():
+# for i in get_device_list():
 #  print i
 
 
-set_parameter(name = "Permittivity", value=(3.9*8.85e-14), **region_info)
-set_parameter(name = "ElectricCharge", value=1.6e-19, **region_info)
+set_parameter(name="Permittivity", value=(3.9 * 8.85e-14), **region_info)
+set_parameter(name="ElectricCharge", value=1.6e-19, **region_info)
 
 print((get_parameter(name="Permittivity", **region_info)))
 print((get_parameter(name="ElectricCharge", **region_info)))
@@ -41,49 +58,69 @@ node_solution(name="ψ", **region_info)
 edge_from_node_model(node_model="ψ", **region_info)
 
 for n, e in (
-    ('ElectricField',              '(ψ@n0 - ψ@n1)*EdgeInverseLength;'),
-    ('ElectricField:ψ@n0', 'EdgeInverseLength;'),
-    ('ElectricField:ψ@n1', '-EdgeInverseLength;')
-) :
-    edge_model(name = n, equation = e, **region_info)
+    ("ElectricField", "(ψ@n0 - ψ@n1)*EdgeInverseLength;"),
+    ("ElectricField:ψ@n0", "EdgeInverseLength;"),
+    ("ElectricField:ψ@n1", "-EdgeInverseLength;"),
+):
+    edge_model(name=n, equation=e, **region_info)
 
-set_parameter(name="topbias",    value = 1.0e-0, **region_info)
+set_parameter(name="topbias", value=1.0e-0, **region_info)
 set_parameter(name="botbias", value=0.0, **region_info)
 
-for n, e in(
-    ("ψEdgeFlux",              "Permittivity*ElectricField;"),
+for n, e in (
+    ("ψEdgeFlux", "Permittivity*ElectricField;"),
     ("ψEdgeFlux:ψ@n0", "diff(Permittivity*ElectricField, ψ@n0);"),
-    ("ψEdgeFlux:ψ@n1", "-ψEdgeFlux:ψ@n0;")
-) :
-    edge_model(name = n, equation = e, **region_info)
+    ("ψEdgeFlux:ψ@n1", "-ψEdgeFlux:ψ@n0;"),
+):
+    edge_model(name=n, equation=e, **region_info)
 
-equation(name="ψEquation", variable_name="ψ", node_model="", edge_model="ψEdgeFlux", time_node_model="", variable_update="default", **region_info)
+equation(
+    name="ψEquation",
+    variable_name="ψ",
+    node_model="",
+    edge_model="ψEdgeFlux",
+    time_node_model="",
+    variable_update="default",
+    **region_info,
+)
 
-conteq="Permittivity*ElectricField;"
-node_model(name="topnode_model",           equation = "ψ - topbias;", **region_info)
-node_model(name="topnode_model:ψ", equation = "1;", **region_info)
-edge_model(name="contactcharge_edge_top",  equation =conteq, **region_info)
+conteq = "Permittivity*ElectricField;"
+node_model(name="topnode_model", equation="ψ - topbias;", **region_info)
+node_model(name="topnode_model:ψ", equation="1;", **region_info)
+edge_model(name="contactcharge_edge_top", equation=conteq, **region_info)
 
-node_model(name = "botnode_model",           equation = "ψ - botbias;", **region_info)
-node_model(name = "botnode_model:ψ", equation = "1;", **region_info)
-edge_model(name = "contactcharge_edge_bottom",  equation =conteq, **region_info)
+node_model(name="botnode_model", equation="ψ - botbias;", **region_info)
+node_model(name="botnode_model:ψ", equation="1;", **region_info)
+edge_model(name="contactcharge_edge_bottom", equation=conteq, **region_info)
 
-contact_equation( device=device , contact= "top" , name= "ψEquation"
-                  , node_model="topnode_model", edge_model= ""
-                  , node_charge_model= "" , edge_charge_model= "contactcharge_edge_top"
-                  , node_current_model= ""   , edge_current_model= "")
+contact_equation(
+    device=device,
+    contact="top",
+    name="ψEquation",
+    node_model="topnode_model",
+    edge_model="",
+    node_charge_model="",
+    edge_charge_model="contactcharge_edge_top",
+    node_current_model="",
+    edge_current_model="",
+)
 
-contact_equation( device=device , contact= "bot" , name= "ψEquation"
-                  , node_model="botnode_model", edge_model= ""
-                  , node_charge_model= "" , edge_charge_model= "contactcharge_edge_bottom"
-                  , node_current_model= ""   , edge_current_model= "")
+contact_equation(
+    device=device,
+    contact="bot",
+    name="ψEquation",
+    node_model="botnode_model",
+    edge_model="",
+    node_charge_model="",
+    edge_charge_model="contactcharge_edge_bottom",
+    node_current_model="",
+    edge_current_model="",
+)
 
 
+solve(type="dc", absolute_error=1.0, relative_error=1e-10, maximum_iterations=30)
 
-solve( type="dc", absolute_error= 1.0 , relative_error= 1e-10 , maximum_iterations= 30)
+print((get_contact_charge(device=device, contact="top", equation="ψEquation")))
+print((get_contact_charge(device=device, contact="bot", equation="ψEquation")))
 
-print((get_contact_charge(device=device , contact="top", equation="ψEquation")))
-print((get_contact_charge(device=device , contact="bot", equation="ψEquation")))
-
-#write_devices(file='cap1.msh', type='devsim')
-
+# write_devices(file='cap1.msh', type='devsim')


### PR DESCRIPTION
*Description of changes:*

This is a followup to #139. 

This PR adds [ruff](https://docs.astral.sh/ruff/) [pre-commit](https://pre-commit.com/) instructions (.pre-commit-config.yaml) to enforce Python formatting. It also adds a Github Actions workflow (.github/workflows/pre_commit.yml) to check this formatting server-side.

The "Contributing" section has been expanded to explain this. The formatting configuration for Python is stored in ruff.toml (currently using defaults, and adding some more excluded directories).

If this is a good idea, in a followup PR, we can add clang pre-commit to autoformat the C++ as well.

*Licensing*

To maintain the integrity of the project, we require contributions to be licensed under the Apache License Version 2.0. Please acknowledge this by checking the box below. By checking the box, you also acknowledge that you have the authority to license your contribution in this manner. You should also ensure that any new file you add contains "# SPDX-License-Identifier: Apache-2.0" in the header.

 - [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](https://apache.org/licenses/LICENSE-2.0).